### PR TITLE
Update status output to match original plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,18 @@ The following types of changes will be recorded in this file:
 
 - placeholder
 
+## [v0.1.2] - 2020-02-06
+
+### Fixed
+
+- Update status output to reflect the same format used in the original Python
+  2 plugin.
+  - For reasons I've yet to spend sufficient time to figure out, the
+    double-quoting used for elements of the "folders" list is lost when sent
+    by Teams or email notifications. It is easier to go ahead and just revert
+    the format for now so it is consistent in each format (console, Teams or
+    email).
+
 ## [v0.1.1] - 2020-02-06
 
 ### Fixed
@@ -57,6 +69,7 @@ monitor mail-related resources.
 - TLS/SSL IMAP4 connectivity via `emerson/go-imap` package
 - Go modules (vs classic `GOPATH` setup)
 
-[Unreleased]: https://github.com/atc0005/check-mail/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/atc0005/check-mail/compare/v0.1.2...HEAD
+[v0.1.2]: https://github.com/atc0005/check-mail/releases/tag/v0.1.2
 [v0.1.1]: https://github.com/atc0005/check-mail/releases/tag/v0.1.1
 [v0.1.0]: https://github.com/atc0005/check-mail/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ required via `stdout`.
 
 ```ShellSession
 $ /usr/lib/nagios/plugins/check_imap_mailbox -folders "Inbox, Junk Email" -server imap.example.com -username "tacotuesdays@example.com" -port 993 -password "coconuts" -log-level disabled
-OK: tacotuesdays@example.com: No messages found in folders: ["Inbox" "Junk Email"]
+OK: tacotuesdays@example.com: No messages found in folders: Inbox, Junk Email
 ```
 
 ### Output

--- a/config.go
+++ b/config.go
@@ -28,7 +28,7 @@ func (i *multiValueFlag) String() string {
 		return ""
 	}
 
-	return strings.Join(*i, ",")
+	return strings.Join(*i, ", ")
 }
 
 // Set is called once by the flag package, in command line order, for each

--- a/main.go
+++ b/main.go
@@ -309,9 +309,9 @@ func main() {
 	// Give the all clear: no mail was found
 	log.Debug().Msg("No messages found to report")
 	nagiosExitState.LastError = nil
-	nagiosExitState.Message = fmt.Sprintf("OK: %s: No messages found in folders: %q",
+	nagiosExitState.Message = fmt.Sprintf("OK: %s: No messages found in folders: %s",
 		config.Username,
-		config.Folders,
+		config.Folders.String(),
 	)
 	nagiosExitState.StatusCode = nagios.StateOK
 


### PR DESCRIPTION
Match the same format used in the original Python 2 plugin.

For reasons I've yet to spend sufficient time to figure out, the double-quoting used for elements of the "folders" list is lost when sent by Teams or email notifications. It is easier to go ahead and just revert the format for now so it is consistent in each format (console, Teams or email).

fixes #16