### PR TITLE
Move golangci-lint settings to external file

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,23 @@
+# Copyright 2020 Adam Chalkley
+#
+# https://github.com/atc0005/check-mail
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+linters:
+  enable:
+    - dogsled
+    - goimports
+    - gosec
+    - stylecheck
+    - goconst
+    - depguard
+    - prealloc
+    - misspell
+    - maligned
+    - dupl
+    - unconvert
+    - golint
+    - gocritic
+    - scopelint

--- a/testing/run_linting_checks.sh
+++ b/testing/run_linting_checks.sh
@@ -76,20 +76,8 @@ make lintinstall
 EOF
     exit 1
 else
-    golangci-lint run \
-        -E goimports \
-        -E gosec \
-        -E stylecheck \
-        -E goconst \
-        -E depguard \
-        -E prealloc \
-        -E misspell \
-        -E maligned \
-        -E dupl \
-        -E unconvert \
-        -E golint \
-        -E gocritic \
-        -E scopelint
+    # Use external config file for linter selection, settings
+    golangci-lint run
 fi
 
 status=$?


### PR DESCRIPTION
This opens up the settings for use with CI, local Makefile linting checks and even with local IDEs that use golangci-lint for linting checks.

fixes #25