### PR TITLE
Update golangci-lint to v1.25.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ VERSION 				= $(shell git describe --always --long --dirty)
 
 # https://github.com/golangci/golangci-lint#install
 # https://github.com/golangci/golangci-lint/releases/latest
-GOLANGCI_LINT_VERSION		= v1.25.0
+GOLANGCI_LINT_VERSION		= v1.25.1
 
 # The default `go build` process embeds debugging information. Building
 # without that debugging information reduces the binary size by around 28%.


### PR DESCRIPTION
v1.26.0 is out, but I'm trying to get all projects to this version before rolling out a newer release that I've not had time to test yet.

- fixes GH-41
- refs atc0005/todo#6