### PR TITLE
Update vendored deps post PR 54

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/emersion/go-imap v1.0.4 h1:uiCAIHM6Z5Jwkma1zdNDWWXxSCqb+/xHBkHflD7XBro=
-github.com/emersion/go-imap v1.0.4/go.mod h1:yKASt+C3ZiDAiCSssxg9caIckWF/JG7ZQTO7GAmvicU=
 github.com/emersion/go-imap v1.0.5 h1:8xg/d2wo2BBP3AEP5AOaM/6i8887RGyVW2st/IVHWUw=
 github.com/emersion/go-imap v1.0.5/go.mod h1:yKASt+C3ZiDAiCSssxg9caIckWF/JG7ZQTO7GAmvicU=
 github.com/emersion/go-message v0.11.1/go.mod h1:C4jnca5HOTo4bGN9YdqNQM9sITuT3Y0K6bSUw9RklvY=

--- a/vendor/github.com/emersion/go-imap/README.md
+++ b/vendor/github.com/emersion/go-imap/README.md
@@ -1,7 +1,7 @@
 # go-imap
 
 [![GoDoc](https://godoc.org/github.com/emersion/go-imap?status.svg)](https://godoc.org/github.com/emersion/go-imap)
-[![builds.sr.ht status](https://builds.sr.ht/~emersion/go-imap.svg)](https://builds.sr.ht/~emersion/go-imap?)
+[![builds.sr.ht status](https://builds.sr.ht/~emersion/go-imap/commits.svg)](https://builds.sr.ht/~emersion/go-imap/commits?)
 [![Codecov](https://codecov.io/gh/emersion/go-imap/branch/master/graph/badge.svg)](https://codecov.io/gh/emersion/go-imap)
 
 An [IMAP4rev1](https://tools.ietf.org/html/rfc3501) library written in Go. It

--- a/vendor/github.com/emersion/go-imap/commands/authenticate.go
+++ b/vendor/github.com/emersion/go-imap/commands/authenticate.go
@@ -109,6 +109,12 @@ func (cmd *Authenticate) Handle(mechanisms map[string]sasl.Server, conn Authenti
 
 		encoded = scanner.Text()
 		if encoded != "" {
+			if encoded == "*" {
+				return &imap.ErrStatusResp{Resp: &imap.StatusResp{
+					Type: imap.StatusRespBad,
+					Info: "negotiation cancelled",
+				}}
+			}
 			response, err = base64.StdEncoding.DecodeString(encoded)
 			if err != nil {
 				return err

--- a/vendor/github.com/emersion/go-imap/message.go
+++ b/vendor/github.com/emersion/go-imap/message.go
@@ -706,14 +706,18 @@ func ParseAddressList(fields []interface{}) (addrs []*Address) {
 }
 
 // Format an address list to fields.
-func FormatAddressList(addrs []*Address) (fields []interface{}) {
-	fields = make([]interface{}, len(addrs))
+func FormatAddressList(addrs []*Address) interface{} {
+	if len(addrs) == 0 {
+		return nil
+	}
+
+	fields := make([]interface{}, len(addrs))
 
 	for i, addr := range addrs {
 		fields[i] = addr.Format()
 	}
 
-	return
+	return fields
 }
 
 // A message envelope, ie. message metadata from its headers.
@@ -806,12 +810,12 @@ type BodyStructure struct {
 	MIMEType string
 	// The MIME subtype (e.g. "plain", "png")
 	MIMESubType string
-	// The MIME parameters. Values are encoded.
+	// The MIME parameters.
 	Params map[string]string
 
 	// The Content-Id header.
 	Id string
-	// The Content-Description header. This is the raw encoded value.
+	// The Content-Description header.
 	Description string
 	// The Content-Encoding header.
 	Encoding string
@@ -836,7 +840,7 @@ type BodyStructure struct {
 
 	// The Content-Disposition header field value.
 	Disposition string
-	// The Content-Disposition header field parameters. Values are encoded.
+	// The Content-Disposition header field parameters.
 	DispositionParams map[string]string
 	// The Content-Language header field, if multipart.
 	Language []string

--- a/vendor/github.com/emersion/go-imap/status.go
+++ b/vendor/github.com/emersion/go-imap/status.go
@@ -118,3 +118,19 @@ func (r *StatusResp) WriteTo(w *Writer) error {
 
 	return w.writeCrlf()
 }
+
+// ErrStatusResp can be returned by a server.Handler to replace the default status
+// response. The response tag must be empty.
+//
+// To suppress default response, Resp should be set to nil.
+type ErrStatusResp struct {
+	// Response to send instead of default.
+	Resp *StatusResp
+}
+
+func (err *ErrStatusResp) Error() string {
+	if err.Resp == nil {
+		return "imap: suppressed response"
+	}
+	return err.Resp.Info
+}

--- a/vendor/github.com/rs/zerolog/internal/cbor/types_test_64.go
+++ b/vendor/github.com/rs/zerolog/internal/cbor/types_test_64.go
@@ -1,0 +1,35 @@
+// +build !386
+
+package cbor
+
+import (
+	"encoding/hex"
+	"testing"
+)
+
+var enc2 = Encoder{}
+
+var integerTestCases_64bit = []struct {
+	val    int
+	binary string
+}{
+	// Value in 8 bytes.
+	{0xabcd100000000, "\x1b\x00\x0a\xbc\xd1\x00\x00\x00\x00"},
+	{1000000000000, "\x1b\x00\x00\x00\xe8\xd4\xa5\x10\x00"},
+	// Value in 8 bytes.
+	{-0xabcd100000001, "\x3b\x00\x0a\xbc\xd1\x00\x00\x00\x00"},
+	{-1000000000001, "\x3b\x00\x00\x00\xe8\xd4\xa5\x10\x00"},
+
+}
+
+func TestAppendInt_64bit(t *testing.T) {
+	for _, tc := range integerTestCases_64bit {
+		s := enc2.AppendInt([]byte{}, tc.val)
+		got := string(s)
+		if got != tc.binary {
+			t.Errorf("AppendInt(0x%x)=0x%s, want: 0x%s",
+				tc.val, hex.EncodeToString(s),
+				hex.EncodeToString([]byte(tc.binary)))
+		}
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,6 +1,6 @@
 # github.com/atc0005/go-nagios v0.2.0
 github.com/atc0005/go-nagios
-# github.com/emersion/go-imap v1.0.4
+# github.com/emersion/go-imap v1.0.5
 github.com/emersion/go-imap
 github.com/emersion/go-imap/client
 github.com/emersion/go-imap/commands


### PR DESCRIPTION
- Update deps after emersion/go-imap v1.0.4 to v1.0.5

- Add dep change re rs/zerolog v1.18.0 to v1.19.0
  - this looks to have been left out from GH-52

refs GH-52, GH-54