### PR TITLE
Update atc0005/go-nagios dep, related fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Various tools used to monitor mail services
   - [Project home](#project-home)
   - [Overview](#overview)
   - [Features](#features)
-    - [`check_imap_mailbox`](#checkimapmailbox)
+    - [`check_imap_mailbox`](#check_imap_mailbox)
     - [`list-emails`](#list-emails)
   - [Requirements](#requirements)
   - [Installation](#installation)
@@ -97,7 +97,7 @@ Tested using:
    - for Linux
      - `make linux`
 1. Copy the applicable binary to whatever systems needs to run it
-   - if using `Makefile`: look in `/tmp/release_assets/check_imap_mailbox/`
+   - if using `Makefile`: look in `/tmp/check-mail/release_assets/check_imap_mailbox/`
    - if using `go build`: look in `/tmp/check-mail/`
 
 ## Configuration Options

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/atc0005/check-mail
 go 1.13
 
 require (
-	github.com/atc0005/go-nagios v0.2.0
+	github.com/atc0005/go-nagios v0.3.0
 	github.com/emersion/go-imap v1.0.5
 	github.com/rs/zerolog v1.19.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/atc0005/go-nagios v0.2.0 h1:1TL4sN+TaoQFvSBLkAoDVdKJ2Qt+eJQgIN944SlmxU4=
-github.com/atc0005/go-nagios v0.2.0/go.mod h1:ZExHMDSmp3B7oqX2Ok+YHjw/tgY10AxOIRTvKAh4o90=
+github.com/atc0005/go-nagios v0.3.0 h1:jV92HjmBO6b5Z+UVoByIZYySvFFtwUlvF+OEcRmPhdI=
+github.com/atc0005/go-nagios v0.3.0/go.mod h1:ZExHMDSmp3B7oqX2Ok+YHjw/tgY10AxOIRTvKAh4o90=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/vendor/github.com/atc0005/go-nagios/.golangci.yml
+++ b/vendor/github.com/atc0005/go-nagios/.golangci.yml
@@ -1,0 +1,24 @@
+# Copyright 2020 Adam Chalkley
+#
+# https://github.com/atc0005/go-nagios
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+linters:
+  enable:
+    - depguard
+    - dogsled
+    - dupl
+    - goconst
+    - gocritic
+    - gofmt
+    - goimports
+    - golint
+    - gosec
+    - maligned
+    - misspell
+    - prealloc
+    - scopelint
+    - stylecheck
+    - unconvert

--- a/vendor/github.com/atc0005/go-nagios/CHANGELOG.md
+++ b/vendor/github.com/atc0005/go-nagios/CHANGELOG.md
@@ -26,6 +26,38 @@ The following types of changes will be recorded in this file:
 
 - placeholder
 
+## [v0.3.0] - 2020-07-05
+
+### Added
+
+- Add State "labels" to provide an alternative to using literal state strings
+
+- Add GitHub Actions Workflow, Makefile for builds
+  - Lint codebase
+  - Build codebase
+
+- Enable Dependabot updates
+  - GitHub Actions
+  - Go Modules
+
+### Changed
+
+- BREAKING: Rename existing exit code constants to explicitly note that they
+  are exit codes
+  - the thinking was that since we have text "labels" for state, it would be
+    good to help clarify the difference between the new constants and the
+    existing exit code constants
+
+- Minor tweaks to README to reference changes, wording
+
+- Update dependencies
+  - `actions/checkout`
+    - `v1` to `v2.3.1`
+  - `actions/setup-go`
+    - `v2.0.3` to `v2.1.0`
+  - `actions/setup-node`
+    - `v1` to `v2.1.0`
+
 ## [v0.2.0] - 2020-02-02
 
 ### Added
@@ -44,6 +76,7 @@ Initial package state
 
 - Nagios state map
 
-[Unreleased]: https://github.com/atc0005/go-nagios/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/atc0005/go-nagios/compare/v0.3.0...HEAD
+[v0.3.0]: https://github.com/atc0005/go-nagios/releases/tag/v0.3.0
 [v0.2.0]: https://github.com/atc0005/go-nagios/releases/tag/v0.2.0
 [v0.1.0]: https://github.com/atc0005/go-nagios/releases/tag/v0.1.0

--- a/vendor/github.com/atc0005/go-nagios/Makefile
+++ b/vendor/github.com/atc0005/go-nagios/Makefile
@@ -1,0 +1,106 @@
+# Copyright 2020 Adam Chalkley
+#
+# https://github.com/atc0005/go-nagios
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+SHELL = /bin/bash
+
+# https://github.com/golangci/golangci-lint#install
+# https://github.com/golangci/golangci-lint/releases/latest
+GOLANGCI_LINT_VERSION		= v1.27.0
+
+BUILDCMD				=	go build -mod=vendor ./...
+GOCLEANCMD				=	go clean -mod=vendor ./...
+GITCLEANCMD				= 	git clean -xfd
+CHECKSUMCMD				=	sha256sum -b
+
+.DEFAULT_GOAL := help
+
+  ##########################################################################
+  # Targets will not work properly if a file with the same name is ever
+  # created in this directory. We explicitly declare our targets to be phony
+  # by making them a prerequisite of the special target .PHONY
+  ##########################################################################
+
+.PHONY: help
+## help: prints this help message
+help:
+	@echo "Usage:"
+	@sed -n 's/^##//p' ${MAKEFILE_LIST} | column -t -s ':' |  sed -e 's/^/ /'
+
+.PHONY: lintinstall
+## lintinstall: install common linting tools
+# https://github.com/golang/go/issues/30515#issuecomment-582044819
+lintinstall:
+	@echo "Installing linting tools"
+
+	@export PATH="${PATH}:$(go env GOPATH)/bin"
+
+	@echo "Explicitly enabling Go modules mode per command"
+	(cd; GO111MODULE="on" go get honnef.co/go/tools/cmd/staticcheck)
+
+	@echo Installing golangci-lint ${GOLANGCI_LINT_VERSION} per official binary installation docs ...
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin ${GOLANGCI_LINT_VERSION}
+	golangci-lint --version
+
+	@echo "Finished updating linting tools"
+
+.PHONY: linting
+## linting: runs common linting checks
+linting:
+	@echo "Running linting tools ..."
+
+	@echo "Running go vet ..."
+	@go vet -mod=vendor $(shell go list -mod=vendor ./... | grep -v /vendor/)
+
+	@echo "Running golangci-lint ..."
+	@golangci-lint run
+
+	@echo "Running staticcheck ..."
+	@staticcheck $(shell go list -mod=vendor ./... | grep -v /vendor/)
+
+	@echo "Finished running linting checks"
+
+.PHONY: gotests
+## gotests: runs go test recursively, verbosely
+gotests:
+	@echo "Running go tests ..."
+	@go test -mod=vendor ./...
+	@echo "Finished running go tests"
+
+.PHONY: goclean
+## goclean: removes local build artifacts, temporary files, etc
+goclean:
+	@echo "Removing object files and cached files ..."
+	@$(GOCLEANCMD)
+
+.PHONY: clean
+## clean: alias for goclean
+clean: goclean
+
+.PHONY: gitclean
+## gitclean: WARNING - recursively cleans working tree by removing non-versioned files
+gitclean:
+	@echo "Removing non-versioned files ..."
+	@$(GITCLEANCMD)
+
+.PHONY: pristine
+## pristine: run goclean and gitclean to remove local changes
+pristine: goclean gitclean
+
+.PHONY: all
+# https://stackoverflow.com/questions/3267145/makefile-execute-another-target
+## all: run all applicable build steps
+all: clean build
+	@echo "Completed build process ..."
+
+.PHONY: build
+## build: ensure that packages build
+build:
+	@echo "Building packages ..."
+
+	$(BUILDCMD)
+
+	@echo "Completed build tasks"

--- a/vendor/github.com/atc0005/go-nagios/README.md
+++ b/vendor/github.com/atc0005/go-nagios/README.md
@@ -10,7 +10,7 @@ Shared Golang package for Nagios plugins
 
 This package contains common types and package-level variables used when
 developing Nagios plugins. The intent is to reduce code duplication between
-various plugins.
+various plugins and help reduce typos associated with literal strings.
 
 ## Features
 
@@ -42,12 +42,20 @@ import (
 )
   ```
 
-Then in your code reference the data types as you would from any other
+Then in your code, reference the data types as you would from any other
 package:
 
 ```golang
 fmt.Println("OK: All checks have passed")
-os.Exit(nagios.StateOK)
+os.Exit(nagios.StateOKExitCode)
+```
+
+Alternatively, you can also use the provided state "labels" (constants) to
+avoid using literal string state values:
+
+```golang
+fmt.Printf("%s: All checks have passed\r\n", nagios.StateOKLabel)
+os.Exit(nagios.StateOKExitCode)
 ```
 
 When you next build your package this one should be pulled in.

--- a/vendor/github.com/atc0005/go-nagios/main.go
+++ b/vendor/github.com/atc0005/go-nagios/main.go
@@ -18,9 +18,20 @@ package nagios
 //
 // See also http://nagios-plugins.org/doc/guidelines.html
 const (
-	StateOK        int = 0
-	StateWARNING   int = 1
-	StateCRITICAL  int = 2
-	StateUNKNOWN   int = 3
-	StateDEPENDENT int = 4
+	StateOKExitCode        int = 0
+	StateWARNINGExitCode   int = 1
+	StateCRITICALExitCode  int = 2
+	StateUNKNOWNExitCode   int = 3
+	StateDEPENDENTExitCode int = 4
+)
+
+// Nagios plugin/service check state "labels". These constants are provided as
+// an alternative to using literal state strings throughout client application
+// code.
+const (
+	StateOKLabel        string = "OK"
+	StateWARNINGLabel   string = "WARNING"
+	StateCRITICALLabel  string = "CRITICAL"
+	StateUNKNOWNLabel   string = "UKNOWN"
+	StateDEPENDENTLabel string = "DEPENDENT"
 )

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/atc0005/go-nagios v0.2.0
+# github.com/atc0005/go-nagios v0.3.0
 github.com/atc0005/go-nagios
 # github.com/emersion/go-imap v1.0.5
 github.com/emersion/go-imap


### PR DESCRIPTION
## Changes

- replace hard-coded status strings with const refs
  - new in `v0.3.0` of `atc0005/go-nagios`
- fix exit code references
  - these have changed as of `v0.3.0` of `atc0005/go-nagios`
- minor README tweaks
  - fix path to generated binaries
  - Markdown VSCode extension (`yzhang.markdown-all-in-one`)
    auto-fixes to ToC

## References

- fixes atc0005/check-mail#61
- refs atc0005/go-nagios#16
