### PR TITLE
Fix Makefile build cmd to create static binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,11 @@
 # https://stackoverflow.com/questions/38801796/makefile-set-if-variable-is-empty
 # https://github.com/golangci/golangci-lint#install
 # https://github.com/golangci/golangci-lint/releases/latest
+# https://golang.org/cmd/link/
+# https://godoc.org/github.com/golang/go/src/os/user
+# https://github.com/go-gitea/gitea/blob/master/Makefile
+# https://golang.org/src/cmd/cgo/doc.go
+# https://github.com/golang/go/issues/26492
 
 SHELL = /bin/bash
 
@@ -42,7 +47,37 @@ VERSION 				= $(shell git describe --always --long --dirty)
 
 # The default `go build` process embeds debugging information. Building
 # without that debugging information reduces the binary size by around 28%.
-BUILDCMD				=	go build -mod=vendor -a -ldflags="-s -w -X $(VERSION_VAR_PKG).version=$(VERSION)"
+#
+# We also include additional flags in an effort to generate static binaries
+# that do not have external dependencies. As of Go 1.15 this still appears to
+# be a mixed bag, so YMMV.
+#
+# See https://github.com/golang/go/issues/26492 for more information.
+#
+# -s
+#	Omit the symbol table and debug information.
+#
+# -w
+#	Omit the DWARF symbol table.
+#
+# -tags 'osusergo,netgo'
+#	Use pure Go implementation of user and group id/name resolution.
+#	Use pure Go implementation of DNS resolver.
+#
+# -extldflags '-static'
+#	Pass 'static' flag to external linker.
+#
+# -linkmode=external
+#	https://golang.org/src/cmd/cgo/doc.go
+#
+#   NOTE: Using external linker requires installation of `gcc-multilib`
+#   package when building 32-bit binaries on a Debian/Ubuntu system. It also
+#   seems to result in an unstable build that crashes on startup. This *might*
+#   be specific to the WSL environment used for builds, but since this is a
+#   new issue and and I do not yet know much about this option, I am leaving
+#   it out.
+BUILDCMD				=	go build -mod=vendor -tags 'osusergo,netgo' -a -ldflags "-extldflags '-static' -s -w -X $(VERSION_VAR_PKG).version=$(VERSION)"
+
 GOCLEANCMD				=	go clean -mod=vendor ./...
 GITCLEANCMD				= 	git clean -xfd
 CHECKSUMCMD				=	sha256sum -b


### PR DESCRIPTION
Fix Makefile build cmd to create static binaries

The previous build command produces dynamic executables
instead of the intended (but not well noted in the Makefile)
static executables. This commit includes changes noted in
upstream `golang/go` issues which appear to work as intended
for others.

I also include doc comments and reference links describing
the use of the updated build options list and some problems
that I encountered during testing of `linkmode=external`.

- fixes GH-94
- refs golang/go 38789
- refs golang/go 26492
