### PR TITLE
Use config.New as intended

### DIFF
--- a/cmd/check_imap_mailbox/main.go
+++ b/cmd/check_imap_mailbox/main.go
@@ -41,7 +41,7 @@ func main() {
 	defer nagiosExitState.ReturnCheckResults()
 
 	// Setup configuration by parsing user-provided flags
-	cfg := config.Config{}
+	cfg := config.New()
 
 	if err := cfg.Validate(); err != nil {
 		// We're using the standalone Err function from rs/zerolog/log as we

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -114,12 +114,12 @@ func Branding(msg string) func() string {
 
 // New is a factory function that produces a new Config object based on user
 // provided flag and config file values.
-func New() (*Config, error) {
+func New() *Config {
 	var config Config
 
 	config.handleFlagsConfig()
 
-	return &config, nil
+	return &config
 
 }
 


### PR DESCRIPTION
- Update `config.New` to remove `error` return value since we
  do not need it

- Use `config.New` as intended instead of empty struct
  assignment

fixes GH-97