### PR TITLE
Explicitly disable use of cgo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@
 # https://godoc.org/github.com/golang/go/src/os/user
 # https://github.com/go-gitea/gitea/blob/master/Makefile
 # https://golang.org/src/cmd/cgo/doc.go
+# https://golang.org/cmd/cgo/
 # https://github.com/golang/go/issues/26492
 
 SHELL = /bin/bash
@@ -76,7 +77,13 @@ VERSION 				= $(shell git describe --always --long --dirty)
 #   be specific to the WSL environment used for builds, but since this is a
 #   new issue and and I do not yet know much about this option, I am leaving
 #   it out.
-BUILDCMD				=	go build -mod=vendor -tags 'osusergo,netgo' -a -ldflags "-extldflags '-static' -s -w -X $(VERSION_VAR_PKG).version=$(VERSION)"
+#
+# CGO_ENABLED=0
+#	https://golang.org/cmd/cgo/
+#	explicitly disable use of cgo
+#	removes potential need for linkage against local c library (e.g., glibc)
+# BUILDCMD				=	go build -mod=vendor -tags 'osusergo,netgo' -a -ldflags "-extldflags '-static' -s -w -X $(VERSION_VAR_PKG).version=$(VERSION)"
+BUILDCMD				=	CGO_ENABLED=0 go build -mod=vendor -a -ldflags "-s -w -X $(VERSION_VAR_PKG).version=$(VERSION)"
 
 GOCLEANCMD				=	go clean -mod=vendor ./...
 GITCLEANCMD				= 	git clean -xfd


### PR DESCRIPTION
As far as I can tell, the v0.2.5 release provided binaries
that are *not* statically linked against glibc and thus
would not be held to LGPL license requirements. AFAICT.

Update Makefile to disable use of cgo for binary generation
in an effort to avoid potential inclusion in the future.

This is likely *not* the last time I'll need to update
the Makefile build options for static binary generation,
but hopefully this will do for now.

refs atc0005/check-mail#94
refs atc0005/mysql2sqlite#48