### PR TITLE
Add version flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Tested using:
 | `port`          | No       | `993`          | No     | *valid IMAP TCP port*                                                   | TCP port used to connect to the remote mail server. This is usually the same port used for TLS encrypted IMAP connections.                                                                  |
 | `logging-level` | No       | `info`         | No     | `disabled`, `panic`, `fatal`, `error`, `warn`, `info`, `debug`, `trace` | Sets log level.                                                                                                                                                                             |
 | `branding`      | No       | `false`        | No     | `true`, `false`                                                         | Toggles emission of branding details with plugin status details. Because this output may not mix well with branding information emitted by other tools, this output is disabled by default. |
+| `version`       | No       | `false`        | No     | `true`, `false`                                                         | Whether to display application version and then immediately exit application                                                                                                                |
 
 ## Examples
 
@@ -176,6 +177,8 @@ Usage of ./check_imap_mailbox:
         The fully-qualified domain name of the remote mail server.
   -username string
         The account used to login to the remote mail server. This is often in the form of an email address.
+  -version
+        Whether to display application version and then immediately exit application.
 ```
 
 ## License

--- a/cmd/check_imap_mailbox/main.go
+++ b/cmd/check_imap_mailbox/main.go
@@ -8,6 +8,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -40,7 +41,13 @@ func main() {
 
 	// Setup configuration by parsing user-provided flags
 	cfg, cfgErr := config.New()
-	if cfgErr != nil {
+	switch {
+	case errors.Is(cfgErr, config.ErrVersionRequested):
+		fmt.Println(config.Version())
+
+		return
+
+	case cfgErr != nil:
 		// We're using the standalone Err function from rs/zerolog/log as we
 		// do not have a working configuration.
 		zlog.Err(cfgErr).Msg("Error initializing application")
@@ -50,8 +57,8 @@ func main() {
 		)
 		nagiosExitState.LastError = cfgErr
 		nagiosExitState.ExitStatusCode = nagios.StateCRITICALExitCode
-		return
 
+		return
 	}
 
 	if cfg.EmitBranding {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,7 @@
 package config
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -22,7 +23,7 @@ import (
 // builds.
 var version string = "x.y.z"
 
-const myAppName string = "check_imap_mailbox"
+const myAppName string = "check-mail"
 const myAppURL string = "https://github.com/atc0005/check-mail"
 
 // Usage is a custom override for the default Help text provided by the flag
@@ -32,6 +33,10 @@ var Usage = func() {
 	fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s:\n", os.Args[0])
 	flag.PrintDefaults()
 }
+
+// ErrVersionRequested indicates that the user requested application version
+// information
+var ErrVersionRequested = errors.New("version information requested")
 
 // multiValueFlag is a custom type that satisfies the flag.Value interface in
 // order to accept multiple values for some of our flags.
@@ -97,6 +102,10 @@ type Config struct {
 	// their own branding output.
 	EmitBranding bool
 
+	// ShowVersion is a flag indicating whether the user opted to display only
+	// the version string and then immediately exit the application.
+	ShowVersion bool
+
 	// Log is an embedded zerolog Logger initialized via config.New().
 	Log zerolog.Logger
 }
@@ -124,6 +133,10 @@ func New() (*Config, error) {
 	var config Config
 
 	config.handleFlagsConfig()
+
+	if config.ShowVersion {
+		return nil, ErrVersionRequested
+	}
 
 	if err := config.validate(); err != nil {
 		return nil, fmt.Errorf("configuration validation failed: %w", err)

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -16,14 +16,16 @@ const (
 	portFlagHelp         string = "TCP port used to connect to the remote mail server. This is usually the same port used for TLS encrypted IMAP connections."
 	loggingLevelFlagHelp string = "Sets log level to one of disabled, panic, fatal, error, warn, info, debug or trace."
 	emitBrandingFlagHelp string = "Toggles emission of branding details with plugin status details. This output is disabled by default."
+	versionFlagHelp      string = "Whether to display application version and then immediately exit application."
 )
 
 // Default flag settings if not overridden by user input
 const (
-	defaultLoggingLevel string = "info"
-	defaultEmitBranding bool   = false
-	defaultPort         int    = 993
-	defaultServer       string = ""
-	defaultPassword     string = ""
-	defaultUsername     string = ""
+	defaultLoggingLevel          string = "info"
+	defaultEmitBranding          bool   = false
+	defaultPort                  int    = 993
+	defaultServer                string = ""
+	defaultPassword              string = ""
+	defaultUsername              string = ""
+	defaultDisplayVersionAndExit bool   = false
 )

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -18,6 +18,7 @@ func (c *Config) handleFlagsConfig() {
 	flag.IntVar(&c.Port, "port", defaultPort, portFlagHelp)
 	flag.StringVar(&c.LoggingLevel, "log-level", defaultLoggingLevel, loggingLevelFlagHelp)
 	flag.BoolVar(&c.EmitBranding, "branding", defaultEmitBranding, emitBrandingFlagHelp)
+	flag.BoolVar(&c.ShowVersion, "version", defaultDisplayVersionAndExit, versionFlagHelp)
 
 	// Allow our function to override the default Help output
 	flag.Usage = Usage


### PR DESCRIPTION
Using `ErrVersionRequested` custom error to short-circuit validation logic. May use this same approach for the
atc0005/dnsc project later.

I've also updated the "application" name shared by the current and future binaries for this project to `check-mail`.

README updates include help text output update and new version flag details.

fixes GH-26