### PR TITLE
Fix ServiceOutput templating for multiple accounts

### DIFF
--- a/cmd/check_imap_mailbox/summary.go
+++ b/cmd/check_imap_mailbox/summary.go
@@ -31,9 +31,8 @@ func setSummary(accounts []config.MailAccount, nes *nagios.ExitState) {
 	}
 
 	nes.ServiceOutput = fmt.Sprintf(
-		"%s: %s: No messages found in specified folders for accounts: %v",
+		"%s: No messages found in specified folders for accounts: %v",
 		nagios.StateOKLabel,
-		accounts[0].Username,
 		accounts,
 	)
 


### PR DESCRIPTION
This isn't currently used as we're only actually handling
one account with the Nagios plugin, but I mistakenly left
the hard-coded reference to the first account in the list
when copy/pasting/modifying the formatted summary.

This commit removes that hard-coded reference to the first
account in the list.