### PR TITLE
Fix breadcrumb URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Copyright 2020 Adam Chalkley
 #
-# https:#github.com/atc0005/check-mail
+# https://github.com/atc0005/check-mail
 #
 # Licensed under the MIT License. See LICENSE file in the project root for
 # full license information.

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,6 +1,6 @@
 # Copyright 2020 Adam Chalkley
 #
-# https:#github.com/atc0005/check-mail
+# https://github.com/atc0005/check-mail
 #
 # Licensed under the MIT License. See LICENSE file in the project root for
 # full license information.


### PR DESCRIPTION
At some point I made a search/replace operation that
unintentionally replaced the `//` characters in the project
URL with a hash mark.

Minor fix to sort that.