### PR TITLE
Tweak description of placeholder character

### DIFF
--- a/internal/files/templates.go
+++ b/internal/files/templates.go
@@ -30,7 +30,7 @@ h5. Overview
 
 | Report generated | {{ .ReportTime.Format "2006-01-02 15:04:05" }} |
 | Summary | {{ .MessagesFoundSummary }} |
-| Placeholder | {{ .UnicodeCharSubstitute }} (substituted for Emoji incompatible with MySQL utf8mb3 character set) |
+| Placeholder character | {{ .UnicodeCharSubstitute }} (substituted for Emoji incompatible with MySQL utf8mb3 character set) |
 
 h5. Emails found
 


### PR DESCRIPTION
The intent for the character was not conveyed well with
"Placeholder", so trying "Placeholder character".

The previous description too closely matches the phrase that
we use to indicate a fake value, so I'm hoping something
more verbose will better communicate the intent.