### PR TITLE
Replace literal octothorpe with equiv HTML entity

### DIFF
--- a/internal/textutils/replace.go
+++ b/internal/textutils/replace.go
@@ -16,6 +16,10 @@ var textileFormattingCharReplacements = map[rune]string{
 
 	// replace pipe characters with HTML entity equivalent
 	'|': "&#124;",
+
+	// replace octothorpe (aka, "hashtag", "pound sign" or "number sign")
+	// character with HTML entity equivalent
+	'#': "&#35;",
 }
 
 // ReplaceAstralUnicode accepts an original string and a replacement string.

--- a/internal/textutils/shared_strings_test.go
+++ b/internal/textutils/shared_strings_test.go
@@ -15,6 +15,10 @@ var formattingTestStrings = []struct {
 		"[EXT] SANS | GIAC Week in Preview – March 28, 2021: New SANS Security Awareness Report™; Graduate Programs Info Session",
 		"[EXT] SANS &#124; GIAC Week in Preview – March 28, 2021: New SANS Security Awareness Report™; Graduate Programs Info Session",
 	},
+	{
+		"[Redmine - Feature #8488] Create an 'Involve' mechanism to private issues",
+		"[Redmine - Feature &#35;8488] Create an 'Involve' mechanism to private issues",
+	},
 }
 
 var unicodeAstralTestStrings = []struct {


### PR DESCRIPTION
- extend Textile formatting character replacement map with entry to handle literal `#` character
- add formatting test strings entry to confirm results

fixes GH-159
