### PR TITLE
Attempt to connect to each server IP before abort

### DIFF
--- a/internal/mbxs/connect.go
+++ b/internal/mbxs/connect.go
@@ -8,7 +8,10 @@
 package mbxs
 
 import (
+	"crypto/tls"
 	"fmt"
+	"net"
+	"strings"
 
 	"github.com/emersion/go-imap/client"
 	"github.com/rs/zerolog"
@@ -18,17 +21,81 @@ import (
 // connection.
 func Connect(server string, port int, logger zerolog.Logger) (*client.Client, error) {
 
-	s := fmt.Sprintf("%s:%d", server, port)
+	logger.Debug().Msg("resolving hostname")
+	addrs, lookupErr := net.LookupHost(server)
+	if lookupErr != nil {
+		errMsg := "error resolving hostname " + server
+		logger.Error().Err(lookupErr).Msg(errMsg)
 
-	logger.Debug().Msg("connecting to remote server")
-	c, err := client.DialTLS(s, nil)
-	if err != nil {
-		errMsg := "error connecting to server"
-		logger.Error().Err(err).Msgf(errMsg)
-
-		return nil, fmt.Errorf("%s: %w", errMsg, err)
+		return nil, fmt.Errorf(
+			"error resolving hostname %s: %w",
+			server,
+			lookupErr,
+		)
 	}
-	logger.Info().Msg("Connected")
+
+	var c *client.Client
+	var connectErr error
+	tlsConfig := &tls.Config{
+		ServerName: server,
+		// NOTE: Explicitly setting minimum TLS version to resolve `G402: TLS
+		// MinVersion too low. (gosec)`
+		//
+		// TODO: Revisit as part of GH-169
+		MinVersion: tls.VersionTLS12,
+	}
+	dialer := &net.Dialer{}
+
+	for _, addr := range addrs {
+		logger.Debug().
+			Str("ip_address", addr).
+			Str("hostname", server).
+			Msg("Connecting to server")
+
+		s := fmt.Sprintf("%s:%d", addr, port)
+
+		// pass in explicitly set TLS config using provided server name, but
+		// attempt to connect to specific IP Address returned from earlier
+		// lookup. We'll attempt to loop over each available IP Address until
+		// we are able to successfully connect to one of them.
+		c, connectErr = client.DialWithDialerTLS(dialer, s, tlsConfig)
+		if connectErr != nil {
+			logger.Error().
+				Err(connectErr).
+				Str("ip_address", addr).
+				Str("hostname", server).
+				Msg("error connecting to server")
+
+			continue
+		}
+
+		// If no connection errors were received, we can consider the
+		// connection attempt a success, clear any previous error and abort
+		// attempts to connect to any remaining IP Addresses for the specified
+		// server name.
+		logger.Info().
+			Str("ip_address", addr).
+			Str("hostname", server).
+			Msg("Connected to server")
+		connectErr = nil
+		break
+	}
+
+	// If all connection attempts failed, report the last connection error.
+	// Log all failed IP Addresses for review.
+	if connectErr != nil {
+		errMsg := fmt.Sprintf(
+			"failed to connect to server using any of %d IP Addresses",
+			len(addrs),
+		)
+		logger.Error().
+			Err(connectErr).
+			Str("failed_ip_addresses", strings.Join(addrs, ", ")).
+			Str("hostname", server).
+			Msg(errMsg)
+
+		return nil, fmt.Errorf("%s: %w", errMsg, connectErr)
+	}
 
 	return c, nil
 


### PR DESCRIPTION
In place of using the `client.DialTLS()` wrapper function, explicitly lookup all IP Addresses and make a connection
attempt to each one using the `client.DialWithDialerTLS()` function.

This is mostly an attempt to workaround failed IPv6 connection attempts, but this failover support should hopefully also make the connection logic more resilient overall.

It's worth noting that all connection attempts are logged at error level, even if later connection attempts to a different IP Address succeed. This *seems* like a good idea, but is worth revisiting (e.g., switch level to `debug`) if it produces too much noise.

fixes GH-166