### PR TITLE
Ignore VSCode workspace settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@
 # vendor/
 
 # Ignore Visual Studio Code workspace-level settings
-/.vscode/settings.json
+/.vscode
 
 # Ignore local "scratch" directory of temporary files
 /scratch


### PR DESCRIPTION
Loosen prior `.vscode` exclusion so that it ignores the entire directory instead of just one of the files. This allows ignoring files/settings created by VSCode extensions in addition to stock VSCode settings.