### PR TITLE
Add initial support for specifying network type

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ This repo contains various tools used to monitor mail services.
   - choice of `disabled`, `panic`, `fatal`, `error`, `warn`, `info` (the
     default), `debug` or `trace`
 - TLS IMAP4 connectivity
-  - defaults to 993/tcp
+  - port defaults to 993/tcp
+  - network type defaults to either of IPv4 and IPv6, but optionally limited
+    to IPv4-only or IPv6-only
 - Optional branding "signature"
   - used to indicate what Nagios plugin (and what version) is responsible for
     the service check result
@@ -84,7 +86,9 @@ This repo contains various tools used to monitor mail services.
     default), `debug` or `trace`
   - bulk of logging directed to per-invocation log file
 - TLS IMAP4 connectivity
-  - defaults to 993/tcp
+  - port defaults to 993/tcp
+  - network type defaults to either of IPv4 and IPv6, but optionally limited
+    to IPv4-only or IPv6-only
 - Minimal output to console unless requested
   - via `debug` logging level
 - Textile (Redmine compatible) formatted report generated per specified email
@@ -191,6 +195,7 @@ Tested using:
 | `password`      | Yes      | *empty string* | No     | *valid password*                                                        | The remote mail server account password.                                                                                                                                                    |
 | `server`        | Yes      | *empty string* | No     | *valid FQDN or IP Address*                                              | The fully-qualified domain name of the remote mail server.                                                                                                                                  |
 | `port`          | No       | `993`          | No     | *valid IMAP TCP port*                                                   | TCP port used to connect to the remote mail server. This is usually the same port used for TLS encrypted IMAP connections.                                                                  |
+| `net-type`      | No       | `auto`         | No     | `auto`, `tcp4`, `tcp6`                                                  | Limits network connections to remote mail servers to one of the specified types.                                                                                                            |
 | `logging-level` | No       | `info`         | No     | `disabled`, `panic`, `fatal`, `error`, `warn`, `info`, `debug`, `trace` | Sets log level.                                                                                                                                                                             |
 | `branding`      | No       | `false`        | No     | `true`, `false`                                                         | Toggles emission of branding details with plugin status details. Because this output may not mix well with branding information emitted by other tools, this output is disabled by default. |
 | `version`       | No       | `false`        | No     | `true`, `false`                                                         | Whether to display application version and then immediately exit application                                                                                                                |
@@ -210,6 +215,7 @@ Tested using:
 | `config-file`     | No       | `accounts.ini` | No     | *valid path to INI configuration file for this application*             | Full path to the INI-formatted configuration file used by this application. See contrib/list-emails/accounts.example.ini for a starter template. Rename to accounts.ini, update with applicable information and place in a directory of your choice. If this file is found in your current working directory you need not use this flag. |
 | `log-file-dir`    | No       | `log`          | No     | *valid, writable path to a directory*                                   | Full path to the directory where log files will be created. The user account running this application requires write permission to this directory. If not specified, a default directory will be created in your current working directory if it does not already exist.                                                                 |
 | `report-file-dir` | No       | `output`       | No     | *valid, writable path to a directory*                                   | Full path to the directory where email summary report files will be created. The user account running this application requires write permission to this directory. If not specified, a default directory will be created in your current working directory if it does not already exist.                                                |
+| `net-type`        | No       | `auto`         | No     | `auto`, `tcp4`, `tcp6`                                                  | Limits network connections to remote mail servers to one of the specified types.                                                                                                                                                                                                                                                         |
 | `logging-level`   | No       | `info`         | No     | `disabled`, `panic`, `fatal`, `error`, `warn`, `info`, `debug`, `trace` | Sets log level.                                                                                                                                                                                                                                                                                                                          |
 | `version`         | No       | `false`        | No     | `true`, `false`                                                         | Whether to display application version and then immediately exit application                                                                                                                                                                                                                                                             |
 

--- a/cmd/check_imap_mailbox/main.go
+++ b/cmd/check_imap_mailbox/main.go
@@ -68,10 +68,11 @@ func main() {
 			Str("username", account.Username).
 			Str("server", account.Server).
 			Int("port", account.Port).
+			Str("network_type", cfg.NetworkType).
 			Str("folders_to_check", account.Folders.String()).
 			Logger()
 
-		c, connectErr := mbxs.Connect(account.Server, account.Port, logger)
+		c, connectErr := mbxs.Connect(account.Server, account.Port, cfg.NetworkType, logger)
 		if connectErr != nil {
 			logger.Error().Err(connectErr).Msgf("error connecting to server")
 			nagiosExitState.LastError = connectErr

--- a/cmd/list-emails/main.go
+++ b/cmd/list-emails/main.go
@@ -85,10 +85,11 @@ func main() {
 			Str("username", account.Username).
 			Str("server", account.Server).
 			Int("port", account.Port).
+			Str("network_type", cfg.NetworkType).
 			Str("folders_to_check", account.Folders.String()).
 			Logger()
 
-		c, connectErr := mbxs.Connect(account.Server, account.Port, logger)
+		c, connectErr := mbxs.Connect(account.Server, account.Port, cfg.NetworkType, logger)
 		if connectErr != nil {
 			logger.Error().Err(connectErr).Msg("failed to connect to server")
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -97,20 +97,25 @@ type Config struct {
 	// the version string and then immediately exit the application.
 	ShowVersion bool
 
-	// configFileLoaded is an internal flag indicating whether a user-provided
+	// ConfigFileLoaded is an internal flag indicating whether a user-provided
 	// config file was specified *and* loaded, or a config file was
 	// automatically detected *and* loaded.
 	ConfigFileLoaded bool
 
-	// configFile is the path to the user-provided config file. This config
+	// ConfigFile is the path to the user-provided config file. This config
 	// file is not currently used by the check_imap_mailbox plugin provided by
 	// this project.
 	ConfigFile string
 
-	// configFileUsed is an internal field indicating *what* config file was
+	// ConfigFileUsed is an internal field indicating *what* config file was
 	// loaded, be it explicitly specified by the user or automatically
 	// detected from a known location.
 	ConfigFileUsed string
+
+	// NetworkType indicates whether an attempt should be made to connect to
+	// only IPv4, only IPv6 or IMAP servers listening on either of IPv4 or
+	// IPv6 addresses ("auto").
+	NetworkType string
 
 	// ReportFileOutputDir is the full path to the directory where email
 	// summary report files will be generated. Not currently used by the
@@ -263,6 +268,14 @@ func (c Config) validate(useConfigFile bool) error {
 			return fmt.Errorf("missing log file output directory")
 		}
 
+	}
+
+	switch c.NetworkType {
+	case netTypeTCPAuto:
+	case netTypeTCP4:
+	case netTypeTCP6:
+	default:
+		return fmt.Errorf("invalid network type keyword: %s", c.NetworkType)
 	}
 
 	requestedLoggingLevel := strings.ToLower(c.LoggingLevel)

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -16,6 +16,7 @@ const (
 	passwordFlagHelp            string = "The remote mail server account password."
 	serverFlagHelp              string = "The fully-qualified domain name of the remote mail server."
 	portFlagHelp                string = "TCP port used to connect to the remote mail server. This is usually the same port used for TLS encrypted IMAP connections."
+	networkTypeFlagHelp         string = "Limits network connections to remote mail servers to one of tcp4 (IPv4-only), tcp6 (IPv6-only) or auto (either)."
 	loggingLevelFlagHelp        string = "Sets log level to one of disabled, panic, fatal, error, warn, info, debug or trace."
 	emitBrandingFlagHelp        string = "Toggles emission of branding details with plugin status details. This output is disabled by default."
 	versionFlagHelp             string = "Whether to display application version and then immediately exit application."
@@ -32,6 +33,7 @@ const (
 	defaultServer                string = ""
 	defaultPassword              string = ""
 	defaultUsername              string = ""
+	defaultNetworkType           string = netTypeTCPAuto
 	defaultDisplayVersionAndExit bool   = false
 
 	// By default these directories are created/used in the user's current
@@ -61,6 +63,18 @@ const (
 	// This will likely require reworking the configuration struct and other
 	// config load behavior.
 	// defaultTOMLConfigFileName string = "config.toml"
+)
+
+const (
+	// netTypeTCPAuto is a custom keyword indicating that either of IPv4 or
+	// IPv6 is an acceptable network type.
+	netTypeTCPAuto string = "auto"
+
+	// netTypeTCP4 indicates that IPv4 network connections are required.
+	netTypeTCP4 string = "tcp4"
+
+	// netTypeTCP6 indicates that IPv6 network connections are required
+	netTypeTCP6 string = "tcp6"
 )
 
 // these keys are found in the `DEFAULT` section of the INI file.

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -21,6 +21,7 @@ func (c *Config) handleFlagsConfig(acceptConfigFile bool) {
 	// shared flags
 	flag.BoolVar(&c.ShowVersion, "version", defaultDisplayVersionAndExit, versionFlagHelp)
 	flag.StringVar(&c.LoggingLevel, "log-level", defaultLoggingLevel, loggingLevelFlagHelp)
+	flag.StringVar(&c.NetworkType, "net-type", defaultNetworkType, networkTypeFlagHelp)
 
 	// currently only applies to list-emails app, don't expose to Nagios plugin
 	if acceptConfigFile {

--- a/internal/mbxs/constants.go
+++ b/internal/mbxs/constants.go
@@ -14,3 +14,18 @@ import "github.com/atc0005/check-mail/internal/textutils"
 // substituting Unicode characters incompatible with the utf8mb3 character
 // set.
 const DefaultReplacementString string = textutils.EmojiScissors
+
+// Known, named networks used for IMAP connections. These names match the
+// network names used by the `net` standard library package.
+const (
+
+	// NetTypeTCPAuto indicates that either of IPv4 or IPv6 will be used to
+	// establish a connection depending on the specified IP Address.
+	NetTypeTCPAuto string = "tcp"
+
+	// NetTypeTCP4 indicates an IPv4-only network.
+	NetTypeTCP4 string = "tcp4"
+
+	// NetTypeTCP6 indicates an IPv6-only network.
+	NetTypeTCP6 string = "tcp6"
+)


### PR DESCRIPTION
Add `net-type` flag to allow limiting network type
to one of `tcp4` (IPv4-only), `tcp6` (IPv6-only) or `auto`
(either). This initial support is implemented by filtering
the DNS query results to either one of the specified network
types, or keeping them all if not user-specified.

Extend logger to include requested network type.

Explcitly log resolved IPs, and IPs remaining after potential
filtering.

Later efforts may expand upon this initial implementation in
order to override the `go-imap/client.(Dialer).Dial()` method
behavior so that we can ignore the hardcoded `tcp` (auto)
value and apply an explicit `tcp4`, `tcp6` or `tcp` network
choice.

Documentation updates applied to cover new flag.

fixes GH-172