### PR TITLE
Override hardcoded tcp (auto) network selection

### DIFF
--- a/internal/mbxs/dialer.go
+++ b/internal/mbxs/dialer.go
@@ -1,0 +1,44 @@
+// Copyright 2021 Adam Chalkley
+//
+// https://github.com/atc0005/check-mail
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package mbxs
+
+import (
+	"net"
+)
+
+// Dialer is an implementation of the go-imap/client.Dialer interface. This
+// implementation is used to override the default "auto" network type
+// selection behavior applied by `Dial*` functions within the go-imap/client
+// package.
+type Dialer struct {
+	// If specified, this value overrides the value supplied to
+	// `go-imap/client.Dial*` functions and is used in its place to establish
+	// a connection on the user-specified network type.
+	NetworkTypeUserOverride string
+
+	// Original value supplied to `go-imap/client.Dial*` functions. Unless
+	// overridden by the user, this value is used to establish a connection on
+	// the supplied network type.
+	NetworkTypeOriginalValue string
+}
+
+// Dial implements the go-imap/client.Dialer interface to override the default
+// "auto" network type selection behavior applied by `Dial*` functions within
+// the go-imap/client package.
+func (d *Dialer) Dial(network string, addr string) (net.Conn, error) {
+
+	// Record the requested network type for potential later use
+	d.NetworkTypeOriginalValue = network
+
+	if d.NetworkTypeUserOverride != "" {
+		network = d.NetworkTypeUserOverride
+	}
+
+	return net.Dial(network, addr)
+
+}


### PR DESCRIPTION
Override the `go-imap/client.Dial*` function behavior so that
we have the option to use user-specified network type instead
of relying entirely on correct auto-selection based on the
hardcoded `tcp` named network.

If overridden, the original hardcoded network name and
user-specified network type is emitted at debug log level
for troubleshooting purposes.

This set of changes is considered an extension of the original
hotfix applied by filtering DNS query results to one of
IPv4-only, IPv6-only or "all".

fixes GH-172