### PR TITLE
Add support for user-specified min TLS version

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ This repo contains various tools used to monitor mail services.
   - port defaults to 993/tcp
   - network type defaults to either of IPv4 and IPv6, but optionally limited
     to IPv4-only or IPv6-only
+  - user-specified minimum TLS version
 - Optional branding "signature"
   - used to indicate what Nagios plugin (and what version) is responsible for
     the service check result
@@ -87,6 +88,7 @@ This repo contains various tools used to monitor mail services.
   - port defaults to 993/tcp
   - network type defaults to either of IPv4 and IPv6, but optionally limited
     to IPv4-only or IPv6-only
+  - user-specified minimum TLS version
 - Minimal output to console unless requested
   - via `debug` logging level
 - Textile (Redmine compatible) formatted report generated per specified email
@@ -194,6 +196,7 @@ Tested using:
 | `server`        | Yes      | *empty string* | No     | *valid FQDN or IP Address*                                              | The fully-qualified domain name of the remote mail server.                                                                                                                                  |
 | `port`          | No       | `993`          | No     | *valid IMAP TCP port*                                                   | TCP port used to connect to the remote mail server. This is usually the same port used for TLS encrypted IMAP connections.                                                                  |
 | `net-type`      | No       | `auto`         | No     | `auto`, `tcp4`, `tcp6`                                                  | Limits network connections to remote mail servers to one of the specified types.                                                                                                            |
+| `min-tls`       | No       | `tls12`        | No     | `tls10`, `tls11`, `tls12`, `tls13`                                      | Limits version of TLS used for connections to remote mail servers.                                                                                                                          |
 | `logging-level` | No       | `info`         | No     | `disabled`, `panic`, `fatal`, `error`, `warn`, `info`, `debug`, `trace` | Sets log level.                                                                                                                                                                             |
 | `branding`      | No       | `false`        | No     | `true`, `false`                                                         | Toggles emission of branding details with plugin status details. Because this output may not mix well with branding information emitted by other tools, this output is disabled by default. |
 | `version`       | No       | `false`        | No     | `true`, `false`                                                         | Whether to display application version and then immediately exit application                                                                                                                |
@@ -214,6 +217,7 @@ Tested using:
 | `log-file-dir`    | No       | `log`          | No     | *valid, writable path to a directory*                                   | Full path to the directory where log files will be created. The user account running this application requires write permission to this directory. If not specified, a default directory will be created in your current working directory if it does not already exist.                                                                 |
 | `report-file-dir` | No       | `output`       | No     | *valid, writable path to a directory*                                   | Full path to the directory where email summary report files will be created. The user account running this application requires write permission to this directory. If not specified, a default directory will be created in your current working directory if it does not already exist.                                                |
 | `net-type`        | No       | `auto`         | No     | `auto`, `tcp4`, `tcp6`                                                  | Limits network connections to remote mail servers to one of the specified types.                                                                                                                                                                                                                                                         |
+| `min-tls`         | No       | `tls12`        | No     | `tls10`, `tls11`, `tls12`, `tls13`                                      | Limits version of TLS used for connections to remote mail servers.                                                                                                                                                                                                                                                                       |
 | `logging-level`   | No       | `info`         | No     | `disabled`, `panic`, `fatal`, `error`, `warn`, `info`, `debug`, `trace` | Sets log level.                                                                                                                                                                                                                                                                                                                          |
 | `version`         | No       | `false`        | No     | `true`, `false`                                                         | Whether to display application version and then immediately exit application                                                                                                                                                                                                                                                             |
 

--- a/cmd/check_imap_mailbox/main.go
+++ b/cmd/check_imap_mailbox/main.go
@@ -68,11 +68,10 @@ func main() {
 			Str("username", account.Username).
 			Str("server", account.Server).
 			Int("port", account.Port).
-			Str("network_type", cfg.NetworkType).
 			Str("folders_to_check", account.Folders.String()).
 			Logger()
 
-		c, connectErr := mbxs.Connect(account.Server, account.Port, cfg.NetworkType, logger)
+		c, connectErr := mbxs.Connect(account.Server, account.Port, cfg.NetworkType, cfg.MinTLSVersion(), logger)
 		if connectErr != nil {
 			logger.Error().Err(connectErr).Msgf("error connecting to server")
 			nagiosExitState.LastError = connectErr

--- a/cmd/list-emails/main.go
+++ b/cmd/list-emails/main.go
@@ -85,11 +85,10 @@ func main() {
 			Str("username", account.Username).
 			Str("server", account.Server).
 			Int("port", account.Port).
-			Str("network_type", cfg.NetworkType).
 			Str("folders_to_check", account.Folders.String()).
 			Logger()
 
-		c, connectErr := mbxs.Connect(account.Server, account.Port, cfg.NetworkType, logger)
+		c, connectErr := mbxs.Connect(account.Server, account.Port, cfg.NetworkType, cfg.MinTLSVersion(), logger)
 		if connectErr != nil {
 			logger.Error().Err(connectErr).Msg("failed to connect to server")
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -117,6 +117,10 @@ type Config struct {
 	// IPv6 addresses ("auto").
 	NetworkType string
 
+	// minTLSVersion is the keyword representing the minimum version of TLS
+	// supported for encrypted IMAP server connections.
+	minTLSVersion string
+
 	// ReportFileOutputDir is the full path to the directory where email
 	// summary report files will be generated. Not currently used by the
 	// Nagios plugin.
@@ -270,7 +274,16 @@ func (c Config) validate(useConfigFile bool) error {
 
 	}
 
-	switch c.NetworkType {
+	switch strings.ToLower(c.minTLSVersion) {
+	case minTLSVersion10:
+	case minTLSVersion11:
+	case minTLSVersion12:
+	case minTLSVersion13:
+	default:
+		return fmt.Errorf("invalid TLS version keyword: %s", c.minTLSVersion)
+	}
+
+	switch strings.ToLower(c.NetworkType) {
 	case netTypeTCPAuto:
 	case netTypeTCP4:
 	case netTypeTCP6:

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -17,6 +17,7 @@ const (
 	serverFlagHelp              string = "The fully-qualified domain name of the remote mail server."
 	portFlagHelp                string = "TCP port used to connect to the remote mail server. This is usually the same port used for TLS encrypted IMAP connections."
 	networkTypeFlagHelp         string = "Limits network connections to remote mail servers to one of tcp4 (IPv4-only), tcp6 (IPv6-only) or auto (either)."
+	minTLSVersionFlagHelp       string = "Limits version of TLS used for connections to remote mail servers to one of tls10 (TLS v1.0), tls11, tls12 or tls13 (TLS v1.3)."
 	loggingLevelFlagHelp        string = "Sets log level to one of disabled, panic, fatal, error, warn, info, debug or trace."
 	emitBrandingFlagHelp        string = "Toggles emission of branding details with plugin status details. This output is disabled by default."
 	versionFlagHelp             string = "Whether to display application version and then immediately exit application."
@@ -34,6 +35,7 @@ const (
 	defaultPassword              string = ""
 	defaultUsername              string = ""
 	defaultNetworkType           string = netTypeTCPAuto
+	defaultMinTLSVersion         string = minTLSVersion12
 	defaultDisplayVersionAndExit bool   = false
 
 	// By default these directories are created/used in the user's current
@@ -75,6 +77,14 @@ const (
 
 	// netTypeTCP6 indicates that IPv6 network connections are required
 	netTypeTCP6 string = "tcp6"
+)
+
+// TLS keywords used to map to TLS versions in the tls stdlib package.
+const (
+	minTLSVersion10 string = "tls10"
+	minTLSVersion11 string = "tls11"
+	minTLSVersion12 string = "tls12"
+	minTLSVersion13 string = "tls13"
 )
 
 // these keys are found in the `DEFAULT` section of the INI file.

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -22,6 +22,7 @@ func (c *Config) handleFlagsConfig(acceptConfigFile bool) {
 	flag.BoolVar(&c.ShowVersion, "version", defaultDisplayVersionAndExit, versionFlagHelp)
 	flag.StringVar(&c.LoggingLevel, "log-level", defaultLoggingLevel, loggingLevelFlagHelp)
 	flag.StringVar(&c.NetworkType, "net-type", defaultNetworkType, networkTypeFlagHelp)
+	flag.StringVar(&c.minTLSVersion, "min-tls", defaultMinTLSVersion, minTLSVersionFlagHelp)
 
 	// currently only applies to list-emails app, don't expose to Nagios plugin
 	if acceptConfigFile {

--- a/internal/config/getters.go
+++ b/internal/config/getters.go
@@ -1,0 +1,46 @@
+// Copyright 2021 Adam Chalkley
+//
+// https://github.com/atc0005/check-mail
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package config
+
+import (
+	"crypto/tls"
+	"strings"
+)
+
+// MinTLSVersion returns the applicable `tls.VersionTLS*` numeric constant
+// corresponding to the user-specified (or default) TLS version string
+// keyword.
+func (c Config) MinTLSVersion() uint16 {
+
+	var tlsVersion uint16
+
+	switch strings.ToLower(c.minTLSVersion) {
+	case minTLSVersion10:
+		tlsVersion = tls.VersionTLS10
+	case minTLSVersion11:
+		tlsVersion = tls.VersionTLS11
+	case minTLSVersion12:
+		tlsVersion = tls.VersionTLS12
+	case minTLSVersion13:
+		tlsVersion = tls.VersionTLS13
+	default:
+		tlsVersion = tls.VersionTLS12
+
+	}
+
+	return tlsVersion
+
+}
+
+// MinTLSVersionKeyword returns the user-specified (or default) TLS version
+// string keyword.
+func (c Config) MinTLSVersionKeyword() string {
+
+	return c.minTLSVersion
+
+}

--- a/internal/config/logging.go
+++ b/internal/config/logging.go
@@ -158,6 +158,8 @@ func (c *Config) setupLogging(useLogFile bool) error {
 	c.Log = zerolog.New(logOutput).With().Caller().
 		Str("version", Version()).
 		Bool("use_log_file", useLogFile).
+		Str("network_type", c.NetworkType).
+		Str("min_tls_version", c.MinTLSVersionKeyword()).
 		Logger()
 
 	if err := setLoggingLevel(c.LoggingLevel); err != nil {

--- a/internal/mbxs/connect.go
+++ b/internal/mbxs/connect.go
@@ -20,7 +20,7 @@ import (
 
 // Connect opens a connection to the specified IMAP server using the specified
 // network type, returns a client connection.
-func Connect(server string, port int, netType string, logger zerolog.Logger) (*client.Client, error) {
+func Connect(server string, port int, netType string, minTLSVer uint16, logger zerolog.Logger) (*client.Client, error) {
 
 	logger.Debug().Msg("resolving hostname")
 	lookupResults, lookupErr := net.LookupHost(server)
@@ -96,13 +96,12 @@ func Connect(server string, port int, netType string, logger zerolog.Logger) (*c
 
 	var c *client.Client
 	var connectErr error
+
+	// #nosec G402; allow user to choose minimum TLS version, fallback to a
+	// secure default
 	tlsConfig := &tls.Config{
 		ServerName: server,
-		// NOTE: Explicitly setting minimum TLS version to resolve `G402: TLS
-		// MinVersion too low. (gosec)`
-		//
-		// TODO: Revisit as part of GH-169
-		MinVersion: tls.VersionTLS12,
+		MinVersion: minTLSVer,
 	}
 
 	for _, addr := range addrs {


### PR DESCRIPTION
- Retain TLS version 1.2 as the minimum TLS version,
  which overrides the stdlib default of TLSv1.0.
- Provide new flag to override app default TLS version
- Doc updates to cover new flag

fixes GH-169