### PR TITLE
Add ref link for TLS version constants

### DIFF
--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -80,6 +80,7 @@ const (
 )
 
 // TLS keywords used to map to TLS versions in the tls stdlib package.
+// https://golang.org/pkg/crypto/tls/#pkg-constants
 const (
 	minTLSVersion10 string = "tls10"
 	minTLSVersion11 string = "tls11"

--- a/internal/config/getters.go
+++ b/internal/config/getters.go
@@ -17,6 +17,7 @@ import (
 // keyword.
 func (c Config) MinTLSVersion() uint16 {
 
+	// https://golang.org/pkg/crypto/tls/#pkg-constants
 	var tlsVersion uint16
 
 	switch strings.ToLower(c.minTLSVersion) {


### PR DESCRIPTION
Useful reminder where the specific values are being pulled.