### PR TITLE
Add version details to Windows executables

### DIFF
--- a/.github/workflows/lint-and-build-using-make.yml
+++ b/.github/workflows/lint-and-build-using-make.yml
@@ -66,10 +66,16 @@ jobs:
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2.3.4
+        with:
+          # Needed in order to retrieve tags for use with go generate
+          fetch-depth: 0
 
       # bsdmainutils provides "column" which is used by the Makefile
       - name: Install Ubuntu packages
         run: apt-get update && apt-get install -y --no-install-recommends make gcc bsdmainutils
+
+      - name: Install go generate dependencies
+        run: make gogeninstall
 
       - name: Build using project Makefile
         run: make all

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+# Files created by gogenerate
+*.syso
+
 # Dependency directories (remove the comment below to include it)
 # vendor/
 

--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,18 @@ lintinstall:
 
 	@echo "Finished updating linting tools"
 
+.PHONY: gogeninstall
+## gogeninstall: install tools used by go generate
+gogeninstall:
+	@echo "Installing go generate dependencies"
+
+	@export PATH="${PATH}:$(go env GOPATH)/bin"
+
+	@echo "Installing go-winres ..."
+	@go install github.com/tc-hib/go-winres@latest
+
+	@echo "Finished installing go generate dependencies"
+
 .PHONY: linting
 ## linting: runs common linting checks
 linting:
@@ -180,8 +192,16 @@ windows:
 
 	@for target in $(WHAT); do \
 		mkdir -p $(OUTPUTDIR)/$$target && \
+		echo "Running go generate for $$target 386 binaries ..." && \
+		cd ./cmd/$$target && \
+		env GOOS=windows GOARCH=386 go generate && \
+		cd $$OLDPWD && \
 		echo "Building $$target 386 binaries" && \
 		env GOOS=windows GOARCH=386 $(BUILDCMD) -o $(OUTPUTDIR)/$$target/$$target-$(VERSION)-windows-386.exe ./cmd/$$target && \
+		echo "Running go generate for amd64 binaries ..." && \
+		cd ./cmd/$$target && \
+		env GOOS=windows GOARCH=amd64 go generate && \
+		cd $$OLDPWD && \
 		echo "Building $$target amd64 binaries" && \
 		env GOOS=windows GOARCH=amd64 $(BUILDCMD) -o $(OUTPUTDIR)/$$target/$$target-$(VERSION)-windows-amd64.exe ./cmd/$$target && \
 		echo "Generating $$target checksum files" && \
@@ -190,6 +210,7 @@ windows:
 		$(CHECKSUMCMD) $$target-$(VERSION)-windows-amd64.exe > $$target-$(VERSION)-windows-amd64.exe.sha256 && \
 		cd $$OLDPWD; \
 	done
+
 
 	@echo "Completed build tasks for windows"
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ This repo contains various tools used to monitor mail services.
   - if building with custom options (as the provided `Makefile` does)
 - `make`
   - if using the provided `Makefile`
+- `tc-hib/go-winres`
+  - if using the provided `Makefile`
+  - used to generate Windows resource files
 
 Tested using:
 
@@ -372,3 +375,4 @@ SOFTWARE.
 - <https://github.com/rs/zerolog>
 - <https://github.com/go-ini/ini>
 - <https://github.com/atc0005/go-nagios>
+- <https://github.com/tc-hib/go-winres>

--- a/cmd/check_imap_mailbox/main.go
+++ b/cmd/check_imap_mailbox/main.go
@@ -5,6 +5,8 @@
 // Licensed under the MIT License. See LICENSE file in the project root for
 // full license information.
 
+//go:generate go-winres make --product-version=git-tag --file-version=git-tag
+
 package main
 
 import (

--- a/cmd/check_imap_mailbox/winres/winres.json
+++ b/cmd/check_imap_mailbox/winres/winres.json
@@ -1,0 +1,53 @@
+{
+  "RT_MANIFEST": {
+    "#1": {
+      "0409": {
+        "identity": {
+          "name": "",
+          "version": ""
+        },
+        "description": "Nagios plugin used to monitor mailboxes for items",
+        "minimum-os": "win7",
+        "execution-level": "as invoker",
+        "ui-access": false,
+        "auto-elevate": false,
+        "dpi-awareness": "system",
+        "disable-theming": false,
+        "disable-window-filtering": false,
+        "high-resolution-scrolling-aware": false,
+        "ultra-high-resolution-scrolling-aware": false,
+        "long-path-aware": false,
+        "printer-driver-isolation": false,
+        "gdi-scaling": false,
+        "segment-heap": false,
+        "use-common-controls-v6": false
+      }
+    }
+  },
+  "RT_VERSION": {
+    "#1": {
+      "0000": {
+        "fixed": {
+          "file_version": "0.0.0.0",
+          "product_version": "0.0.0.0"
+        },
+        "info": {
+          "0409": {
+            "Comments": "Part of the atc0005/check-mail project",
+            "CompanyName": "github.com/atc0005",
+            "FileDescription": "Nagios plugin used to monitor mailboxes for items",
+            "FileVersion": "",
+            "InternalName": "check_imap_mailbox",
+            "LegalCopyright": "© Adam Chalkley. Licensed under MIT.",
+            "LegalTrademarks": "",
+            "OriginalFilename": "main.go",
+            "PrivateBuild": "",
+            "ProductName": "check-mail",
+            "ProductVersion": "",
+            "SpecialBuild": ""
+          }
+        }
+      }
+    }
+  }
+}

--- a/cmd/list-emails/main.go
+++ b/cmd/list-emails/main.go
@@ -5,6 +5,8 @@
 // Licensed under the MIT License. See LICENSE file in the project root for
 // full license information.
 
+//go:generate go-winres make --product-version=git-tag --file-version=git-tag
+
 package main
 
 import (

--- a/cmd/list-emails/winres/winres.json
+++ b/cmd/list-emails/winres/winres.json
@@ -1,0 +1,53 @@
+{
+  "RT_MANIFEST": {
+    "#1": {
+      "0409": {
+        "identity": {
+          "name": "",
+          "version": ""
+        },
+        "description": "Small CLI app used to generate listing of mailbox contents",
+        "minimum-os": "win7",
+        "execution-level": "as invoker",
+        "ui-access": false,
+        "auto-elevate": false,
+        "dpi-awareness": "system",
+        "disable-theming": false,
+        "disable-window-filtering": false,
+        "high-resolution-scrolling-aware": false,
+        "ultra-high-resolution-scrolling-aware": false,
+        "long-path-aware": false,
+        "printer-driver-isolation": false,
+        "gdi-scaling": false,
+        "segment-heap": false,
+        "use-common-controls-v6": false
+      }
+    }
+  },
+  "RT_VERSION": {
+    "#1": {
+      "0000": {
+        "fixed": {
+          "file_version": "0.0.0.0",
+          "product_version": "0.0.0.0"
+        },
+        "info": {
+          "0409": {
+            "Comments": "Part of the atc0005/check-mail project",
+            "CompanyName": "github.com/atc0005",
+            "FileDescription": "Small CLI app used to generate listing of mailbox contents",
+            "FileVersion": "",
+            "InternalName": "list-emails",
+            "LegalCopyright": "© Adam Chalkley. Licensed under MIT.",
+            "LegalTrademarks": "",
+            "OriginalFilename": "main.go",
+            "PrivateBuild": "",
+            "ProductName": "check-mail",
+            "ProductVersion": "",
+            "SpecialBuild": ""
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Use `tc-hib/go-winres` tool to generate Windows resource
files for inclusion in generated Windows executables.

Update README file to list dependency when building from
source using the provided Makefile.

Update CI build job to install `tc-hib/go-winres` prior
to building using Makefile, perform full fetch including
tags/history in order to provide tag details to the
`tc-hib/go-winres` tool (file version metadata).

fixes GH-200