### PR TITLE
Ignore false-positive gosec G307 linting errors

### DIFF
--- a/cmd/list-emails/main.go
+++ b/cmd/list-emails/main.go
@@ -62,6 +62,9 @@ func main() {
 		return
 	}
 
+	// #nosec G307
+	// Believed to be a false-positive from recent gosec release
+	// https://github.com/securego/gosec/issues/714
 	defer func(filename string) {
 		if err := cfg.LogFileHandle.Close(); err != nil {
 			// Ignore "file already closed" errors

--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -40,6 +40,10 @@ func (c *Config) readConfigFile(configFile ...string) ([]byte, error) {
 			continue
 		}
 		c.Log.Debug().Str("config_file", file).Msg("Config file opened")
+
+		// #nosec G307
+		// Believed to be a false-positive from recent gosec release
+		// https://github.com/securego/gosec/issues/714
 		defer func() {
 			if err := fh.Close(); err != nil {
 				// Ignore "file already closed" errors

--- a/internal/files/report.go
+++ b/internal/files/report.go
@@ -100,6 +100,9 @@ func GenerateReport(reportData ReportData, reportDirectory string, logger zerolo
 
 	logger.Debug().Msg("Successfully opened report file for updates")
 
+	// #nosec G307
+	// Believed to be a false-positive from recent gosec release
+	// https://github.com/securego/gosec/issues/714
 	defer func(filename string) {
 		if err := f.Close(); err != nil {
 			// Ignore "file already closed" errors


### PR DESCRIPTION
Issues reported after upgrading golangci-lint to v1.43.0. gosec was updated in that version from v2.8.1 to v2.9.1.

refs atc0005/check-mail#234
refs golangci/golangci-lint#2299