### PR TITLE
Add missing GHAW build steps for list-emails

### DIFF
--- a/.github/workflows/lint-and-build-code.yml
+++ b/.github/workflows/lint-and-build-code.yml
@@ -79,7 +79,23 @@ jobs:
 
       - name: Check out code
         uses: actions/checkout@v2.4.0
+        with:
+          # We need the tags in order to use go-winres 'git-tag' option. This
+          # option is reliant on tags.
+          fetch-depth: 0
+
+      - name: Install go generate dependencies
+        run: |
+          go install github.com/tc-hib/go-winres@latest
+          go-winres --help
 
       - name: Build using vendored dependencies
         run: |
+          # Normal Linux builds
           go build -v -mod=vendor ./cmd/check_imap_mailbox
+          go build -v -mod=vendor ./cmd/list-emails
+
+          # Windows specific build to test go-winres functionality
+          go generate -v ./cmd/list-emails
+          GOOS=windows go build -v -mod=vendor ./cmd/list-emails
+          ls -la


### PR DESCRIPTION
- Modify actions/checkout step to clone full repo instead
  of only the last commit
  - go-winres tool needs git tags for its work
- Add install & help flag steps for `go-winres`
- Add build steps for `list-emails`
  - standard Linux build
  - go generate step
  - Windows specific build
  - list directory contents for troubleshooting purposes

fixes GH-249