### PR TITLE
Add go-winres canary file

### DIFF
--- a/dependabot/tools/go.mod
+++ b/dependabot/tools/go.mod
@@ -1,0 +1,9 @@
+module github.com/atc0005/check-mail/dependabot/tools
+
+go 1.14
+
+require (
+	// go-winres - used by go generate build step
+	github.com/tc-hib/go-winres v0.2.3
+
+)

--- a/dependabot/tools/tools.go
+++ b/dependabot/tools/tools.go
@@ -1,0 +1,13 @@
+// +build tools
+
+package tools
+
+// Manage tool dependencies via go.mod.
+//
+// https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
+// https://github.com/golang/go/issues/25922
+//
+// nolint
+import (
+	_ "github.com/tc-hib/go-winres"
+)


### PR DESCRIPTION
- Add tools.go and go.mod files to track go-winres releases
- Explicitly specify one version back (v0.2.3) to test
  Dependabot monitoring of go-winres release versions

Place the files in the same path as the Go Dockerfile used for a similar purpose.

fixes GH-248