### PR TITLE
Use errors.Is() to replace direct errors compare

### DIFF
--- a/internal/textutils/inspect_test.go
+++ b/internal/textutils/inspect_test.go
@@ -8,6 +8,7 @@
 package textutils
 
 import (
+	"errors"
 	"os"
 	"testing"
 )
@@ -23,7 +24,7 @@ func TestInspectAstralUnicodeStrings(t *testing.T) {
 		var want error
 		got := InspectString(v.original, os.Stderr)
 
-		if got != want {
+		if !errors.Is(got, want) {
 			t.Error("Expected", want, "Got", got)
 		}
 	}
@@ -42,7 +43,7 @@ func TestInspectFormattingStrings(t *testing.T) {
 		var want error
 		got := InspectString(v.original, os.Stderr)
 
-		if got != want {
+		if !errors.Is(got, want) {
 			t.Error("Expected", want, "Got", got)
 		}
 	}


### PR DESCRIPTION
Fix err113 linter warning re comparing errors directly by using `errors.Is()` in tests.

fixes GH-274