### PR TITLE
Apply Go 1.19 specific doc comments linting fixes

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,26 +1,23 @@
 /*
-
 This repo contains various tools used to monitor mail services.
 
-PROJECT HOME
+# PROJECT HOME
 
 See our GitHub repo (https://github.com/atc0005/check-mail) for the latest
 code, to file an issue or submit improvements for review and potential
 inclusion into the project.
 
-PURPOSE
+# PURPOSE
 
 Monitor remote mail services.
 
-FEATURES
+# FEATURES
 
-• Nagios plugin for monitoring one or more remote IMAP mailboxes
+  - Nagios plugin for monitoring one or more remote IMAP mailboxes
+  - Command-line tool for generating reports of specified folders/mailboxes
 
-• Command-line tool for generating reports of specified folders/mailboxes
-
-USAGE
+# USAGE
 
 See our main README for supported settings and examples.
-
 */
 package main


### PR DESCRIPTION
These changes are effectively a NOOP for earlier Go versions, but improve the formatting of rendered documentation.