### PR TITLE
Add missing cmd doc files

### DIFF
--- a/cmd/check_imap_mailbox/doc.go
+++ b/cmd/check_imap_mailbox/doc.go
@@ -1,0 +1,18 @@
+// Copyright 2020 Adam Chalkley
+//
+// https://github.com/atc0005/check-mail
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+// Small CLI app used to generate listing of mailbox contents.
+//
+// See our [GitHub repo]:
+//
+//   - to review documentation (including examples)
+//   - for the latest code
+//   - to file an issue or submit improvements for review and potential
+//     inclusion into the project
+//
+// [GitHub repo]: https://github.com/atc0005/check-mail
+package main

--- a/cmd/list-emails/doc.go
+++ b/cmd/list-emails/doc.go
@@ -1,0 +1,18 @@
+// Copyright 2020 Adam Chalkley
+//
+// https://github.com/atc0005/check-mail
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+// Nagios plugin used to monitor mailboxes for items.
+//
+// See our [GitHub repo]:
+//
+//   - to review documentation (including examples)
+//   - for the latest code
+//   - to file an issue or submit improvements for review and potential
+//     inclusion into the project
+//
+// [GitHub repo]: https://github.com/atc0005/check-mail
+package main


### PR DESCRIPTION
Add "package" doc files to resolve revive `package-comment`
linting error surfaced by recent linter update.