### PR TITLE
Update project to Go 1.19

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -110,5 +110,5 @@ updates:
         versions:
           # Ignore updates from series associated with the latest "stable"
           # Go release and no longer supported Go versions.
-          - ">= 1.18"
-          - "< 1.17"
+          - ">= 1.20"
+          - "< 1.19"

--- a/dependabot/docker/go/Dockerfile
+++ b/dependabot/docker/go/Dockerfile
@@ -15,4 +15,4 @@
 # binaries) to reflect that version of Go.
 
 # https://hub.docker.com/_/golang
-FROM golang:1.17.13
+FROM golang:1.19.0

--- a/dependabot/tools/go.mod
+++ b/dependabot/tools/go.mod
@@ -1,6 +1,15 @@
 module github.com/atc0005/check-mail/dependabot/tools
 
-go 1.14
+go 1.19
 
 // go-winres - used by go generate build step
 require github.com/tc-hib/go-winres v0.3.0
+
+require (
+	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
+	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/tc-hib/winres v0.1.6 // indirect
+	github.com/urfave/cli/v2 v2.3.0 // indirect
+	golang.org/x/image v0.0.0-20210220032944-ac19c3e999fb // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/atc0005/check-mail
 
-go 1.17
+go 1.19
 
 require (
 	github.com/atc0005/go-nagios v0.9.1


### PR DESCRIPTION
- update project go.mod file from Go 1.17 to 1.19
- update tools go.mod file from Go 1.14 to 1.19
- update "Canary" Dockerfile to reflect current Go 1.19 version
- update Dependabot configuration for Dockerfile to ignore Go
  releases outside of the Go 1.19 release series