### PR TITLE
Skip `LOGIN` attempt if `LOGINDISABLED` is set

### DIFF
--- a/internal/mbxs/constants.go
+++ b/internal/mbxs/constants.go
@@ -29,3 +29,22 @@ const (
 	// NetTypeTCP6 indicates an IPv6-only network.
 	NetTypeTCP6 string = "tcp6"
 )
+
+// IMAP commands
+const (
+
+	// The LOGIN command identifies the client to the server and carries the
+	// plaintext password authenticating this user.
+	// https://datatracker.ietf.org/doc/html/rfc3501#section-6.2.3
+	IMAPv4CommandLogin string = "LOGIN"
+)
+
+// IMAP capabilities
+const (
+
+	// The LOGINDISABLED capability indicates that the LOGIN command is not
+	// permitted. This is most often due to TLS not active for the current
+	// connection.
+	// https://datatracker.ietf.org/doc/html/rfc3501#section-6.1.1
+	IMAPv4CapabilityLoginDisabled string = "LOGINDISABLED"
+)


### PR DESCRIPTION
In short, do not attempt to login if the IMAP server has indicated that logins are disabled for the current connection (state).

CHANGES:

- doc comment tweaks
- warn if TLS is not enabled when performing login attempt
- early exit if unable to detect whether the `LOGINDISABLED` capability is set by the IMAP server
- early exit if `LOGINDISABLED` capability is confirmed to be set by the IMAP server

REFERENCES:

- fixes GH-321
- https://datatracker.ietf.org/doc/html/rfc3501#section-6.1.1
- https://datatracker.ietf.org/doc/html/rfc3501#section-6.2.3