### PR TITLE
Fix doc.go description for list-emails CLI app

### DIFF
--- a/cmd/list-emails/doc.go
+++ b/cmd/list-emails/doc.go
@@ -5,7 +5,7 @@
 // Licensed under the MIT License. See LICENSE file in the project root for
 // full license information.
 
-// Nagios plugin used to monitor mailboxes for items.
+// Small CLI app used to generate listing of mailbox contents.
 //
 // See our [GitHub repo]:
 //


### PR DESCRIPTION
Looks like a bad copy/paste/modify attempt from the check_imap_mailbox plugin.