### PR TITLE
Refactor config logic to support app types

### DIFF
--- a/cmd/check_imap_mailbox/main.go
+++ b/cmd/check_imap_mailbox/main.go
@@ -31,13 +31,8 @@ func main() {
 	// defer this from the start so it is the last deferred function to run
 	defer nagiosExitState.ReturnCheckResults()
 
-	// Setup configuration by parsing user-provided flags. This plugin does
-	// not currently support retrieving settings from a user-provided config
-	// file. Because this may change in the near future, we are structuring
-	// this plugin in a way to support that direction.
-	useConfigFile := false
-	useLogFile := false
-	cfg, cfgErr := config.New(useConfigFile, useLogFile)
+	// Setup configuration by parsing user-provided flags.
+	cfg, cfgErr := config.New(config.AppType{PluginIMAPMailboxBasicAuth: true})
 	switch {
 	case errors.Is(cfgErr, config.ErrVersionRequested):
 		fmt.Println(config.Version())

--- a/cmd/list-emails/main.go
+++ b/cmd/list-emails/main.go
@@ -40,9 +40,7 @@ func main() {
 	}(&appExitStatus)
 
 	// Setup configuration by parsing user-provided flags
-	useConfigFile := true
-	useLogFile := true
-	cfg, cfgErr := config.New(useConfigFile, useLogFile)
+	cfg, cfgErr := config.New(config.AppType{ReporterIMAPMailboxBasicAuth: true})
 	switch {
 	case errors.Is(cfgErr, config.ErrVersionRequested):
 		fmt.Println(config.Version())

--- a/internal/config/logging.go
+++ b/internal/config/logging.go
@@ -96,14 +96,17 @@ func setLoggingLevel(logLevel string) error {
 
 // setupLogging is responsible for configuring logging settings for this
 // application
-func (c *Config) setupLogging(useLogFile bool) error {
+func (c *Config) setupLogging(appType AppType) error {
 
 	var logOutput io.Writer
 
-	// we want to log to a file only for list-emails
-
+	var useLogFile bool
 	switch {
-	case useLogFile:
+
+	// we want to log to a file only for list-emails
+	case appType.ReporterIMAPMailboxBasicAuth:
+
+		useLogFile = true
 
 		logFilename := fmt.Sprintf(
 			logFilenameTemplate,
@@ -135,6 +138,10 @@ func (c *Config) setupLogging(useLogFile bool) error {
 
 		// TODO: Set c.LogFileHandle to the newly opened file
 	default:
+
+		// Explicitly note that we disable use of a log file for all
+		// other application types.
+		useLogFile = false
 
 		// Nagios doesn't look at stderr, only stdout. We have to make sure
 		// that only whatever output is meant for consumption is emitted to

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1,0 +1,166 @@
+// Copyright 2020 Adam Chalkley
+//
+// https://github.com/atc0005/check-mail
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package config
+
+import (
+	"fmt"
+	"strings"
+)
+
+func validateTLSVersion(c Config) error {
+	switch strings.ToLower(c.minTLSVersion) {
+	case minTLSVersion10:
+		return nil
+	case minTLSVersion11:
+		return nil
+	case minTLSVersion12:
+		return nil
+	case minTLSVersion13:
+		return nil
+	default:
+		return fmt.Errorf("invalid TLS version keyword: %s", c.minTLSVersion)
+	}
+}
+
+func validateNetworkType(c Config) error {
+	switch strings.ToLower(c.NetworkType) {
+	case netTypeTCPAuto:
+		return nil
+	case netTypeTCP4:
+		return nil
+	case netTypeTCP6:
+		return nil
+	default:
+		return fmt.Errorf("invalid network type keyword: %s", c.NetworkType)
+	}
+}
+
+func validateLoggingLevels(c Config) error {
+	requestedLoggingLevel := strings.ToLower(c.LoggingLevel)
+	if _, ok := loggingLevels[requestedLoggingLevel]; !ok {
+		return fmt.Errorf("invalid logging level %s", c.LoggingLevel)
+	}
+
+	return nil
+}
+
+func validateAccounts(c Config) error {
+	for _, account := range c.Accounts {
+		if account.Folders == nil {
+			return fmt.Errorf(
+				"one or more folders not provided for account %s",
+				account.Name,
+			)
+		}
+
+		if account.Port < 0 {
+			return fmt.Errorf(
+				"invalid TCP port number %d provided for account %s",
+				account.Port,
+				account.Name,
+			)
+		}
+
+		if account.Username == "" {
+			return fmt.Errorf("username not provided for account %s",
+				account.Name,
+			)
+		}
+
+		if account.Password == "" {
+			return fmt.Errorf("password not provided for account %s",
+				account.Name,
+			)
+		}
+
+		if account.Server == "" {
+			return fmt.Errorf("server FQDN not provided for account %s",
+				account.Name,
+			)
+		}
+	}
+
+	return nil
+}
+
+// validate verifies all Config struct fields have been provided acceptable
+// values.
+func (c Config) validate(appType AppType) error {
+
+	switch {
+	case appType.PluginIMAPMailboxBasicAuth:
+
+		if err := validateAccounts(c); err != nil {
+			return err
+		}
+
+		if err := validateTLSVersion(c); err != nil {
+			return err
+		}
+
+		if err := validateNetworkType(c); err != nil {
+			return err
+		}
+
+		if err := validateLoggingLevels(c); err != nil {
+			return err
+		}
+
+	case appType.ReporterIMAPMailboxBasicAuth:
+
+		// NOTE: It's fine to *not* specify a config file. The expected behavior
+		// is that specifying a config file will be a rare thing; users will more
+		// often than not rely on config file auto-detection behavior.
+		//
+		// That said, if a user does not specify a config file, we need to require
+		// that one was found and loaded.
+		//
+		// if useConfigFile {
+		// 	if c.ConfigFile == "" {
+		// 		return fmt.Errorf("config file required, but not specified")
+		// 	}
+		// }
+
+		// set with a default value if not specified by the user, so should not
+		// ever be empty
+		if c.ReportFileOutputDir == "" {
+			return fmt.Errorf("missing report file output directory")
+		}
+
+		// set with a default value if not specified by the user, so should not
+		// ever be empty
+		if c.LogFileOutputDir == "" {
+			return fmt.Errorf("missing log file output directory")
+		}
+
+		if err := validateAccounts(c); err != nil {
+			return err
+		}
+
+		if err := validateTLSVersion(c); err != nil {
+			return err
+		}
+
+		if err := validateNetworkType(c); err != nil {
+			return err
+		}
+
+		if err := validateLoggingLevels(c); err != nil {
+			return err
+		}
+
+	default:
+		return fmt.Errorf(
+			"unable to validate configuration: %w",
+			ErrAppTypeNotSpecified,
+		)
+	}
+
+	// Optimist
+	return nil
+}


### PR DESCRIPTION
Rework configuration handling to allow different logic based on the app type. At present there are two app types, but this is expected to change soon.

fixes GH-324