### PR TITLE
Fix failure to save account details

### DIFF
--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -39,8 +39,6 @@ func (c *Config) handleFlagsConfig(appType AppType) {
 		flag.StringVar(&account.Server, "server", defaultServer, serverFlagHelp)
 		flag.IntVar(&account.Port, "port", defaultPort, portFlagHelp)
 		flag.BoolVar(&c.EmitBranding, "branding", defaultEmitBranding, emitBrandingFlagHelp)
-
-		c.Accounts = append(c.Accounts, account)
 	}
 
 	// Allow our function to override the default Help output
@@ -48,5 +46,12 @@ func (c *Config) handleFlagsConfig(appType AppType) {
 
 	// parse flag definitions from the argument list
 	flag.Parse()
+
+	// For all app types other than the Reporter app we need to save any
+	// configured account details provided via CLI; the Reporter app receives
+	// all account details via configuration file.
+	if !appType.ReporterIMAPMailboxBasicAuth {
+		c.Accounts = append(c.Accounts, account)
+	}
 
 }


### PR DESCRIPTION
Collect parsed account flag values after all flags have been parsed (as before). Restore conditional logic to apply this step for all app types other than Reporter app.