### PR TITLE
Add lsimap troubleshooting tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@
 # Ignore binaries at root of repo (often generated here when testing)
 /check_imap_mailbox
 /list-emails
+/lsimap
 
 # Help prevent accidentally including this credentials file in the repo
 /accounts.ini

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@
 SHELL = /bin/bash
 
 # Space-separated list of cmd/BINARY_NAME directories to build
-WHAT 					= check_imap_mailbox list-emails
+WHAT 					= check_imap_mailbox list-emails lsimap
 
 # TODO: This will need to be standardized across all cmd files in order to
 # work as intended.

--- a/cmd/check_imap_mailbox/main.go
+++ b/cmd/check_imap_mailbox/main.go
@@ -81,6 +81,7 @@ func main() {
 
 			return
 		}
+		logger.Debug().Msg("Connection established to server")
 
 		if loginErr := mbxs.Login(c, account.Username, account.Password, logger); loginErr != nil {
 			logger.Error().Err(loginErr).Msg("Login error occurred")

--- a/cmd/list-emails/main.go
+++ b/cmd/list-emails/main.go
@@ -100,6 +100,7 @@ func main() {
 
 			return
 		}
+		logger.Info().Msg("Connection established to server")
 
 		if loginErr := mbxs.Login(c, account.Username, account.Password, logger); loginErr != nil {
 			logger.Error().Err(loginErr).Msg("failed to login to server")

--- a/cmd/lsimap/doc.go
+++ b/cmd/lsimap/doc.go
@@ -1,0 +1,18 @@
+// Copyright 2022 Adam Chalkley
+//
+// https://github.com/atc0005/check-mail
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+// Small CLI tool to list advertised capabilities for specified IMAP server.
+//
+// See our [GitHub repo]:
+//
+//   - to review documentation (including examples)
+//   - for the latest code
+//   - to file an issue or submit improvements for review and potential
+//     inclusion into the project
+//
+// [GitHub repo]: https://github.com/atc0005/check-mail
+package main

--- a/cmd/lsimap/main.go
+++ b/cmd/lsimap/main.go
@@ -1,0 +1,98 @@
+// Copyright 2022 Adam Chalkley
+//
+// https://github.com/atc0005/check-mail
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+//go:generate go-winres make --product-version=git-tag --file-version=git-tag
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/atc0005/check-mail/internal/config"
+	"github.com/atc0005/check-mail/internal/mbxs"
+	"github.com/rs/zerolog"
+)
+
+func main() {
+
+	// Setup configuration by parsing user-provided flags
+	cfg, cfgErr := config.New(config.AppType{InspectorIMAPCaps: true})
+	switch {
+	case errors.Is(cfgErr, config.ErrVersionRequested):
+		fmt.Println(config.Version())
+
+		return
+
+	case cfgErr != nil:
+
+		// We make some assumptions when setting up our logger as we do not
+		// have a working configuration based on sysadmin-specified choices.
+		consoleWriter := zerolog.ConsoleWriter{Out: os.Stderr}
+		logger := zerolog.New(consoleWriter).With().Timestamp().Caller().Logger()
+
+		logger.Err(cfgErr).Msg("Error initializing application")
+
+		return
+	}
+
+	logger := cfg.Log.With().Logger()
+
+	// We're reusing the common "Accounts" field (and flags) in order to
+	// obtain specified server and port values vs adding standalone fields and
+	// flags; this is effectively a loop of 1 iteration (at least for now). At
+	// some point we may expand the scope of this tool to handle evaluating
+	// mail servers for a collection of accounts, so using a workflow intended
+	// for collections is probably appropriate.
+	for _, account := range cfg.Accounts {
+
+		// Open connection to IMAP server
+		c, err := mbxs.Connect(account.Server, account.Port, cfg.NetworkType, cfg.MinTLSVersion(), logger)
+		if err != nil {
+			logger.Error().Err(err).Msg("error connecting to server")
+			os.Exit(1)
+		}
+		logger.Info().Msg("Connection established to server")
+
+		// Enable client network command/response logging if global logging
+		// level indicates user wishes to see verbose details.
+		if zerolog.GlobalLevel() == zerolog.DebugLevel ||
+			zerolog.GlobalLevel() == zerolog.TraceLevel {
+			c.SetDebug(&logger)
+		}
+
+		logger.Info().Msg("Gathering pre-login capabilities")
+		capabilities, err := c.Capability()
+		if err != nil {
+			logger.Error().Err(err).Msg("Unable to list server capabilities")
+			os.Exit(1)
+		}
+
+		caps := make([]string, 0, len(capabilities))
+		for k, v := range capabilities {
+			if v {
+				caps = append(caps, k)
+			}
+		}
+
+		sort.Strings(caps)
+		// logger.Info().Msgf("Capabilities: %v", caps)
+		for _, capability := range caps {
+			logger.Info().Msgf("Capability: %v", capability)
+		}
+
+		logger.Debug().Msg("Closing connection to server")
+		if err := c.Logout(); err != nil {
+			logger.Error().Err(err).Msg("failed to close connection to server")
+			os.Exit(1)
+		}
+		logger.Info().Msg("Connection to server closed")
+
+	}
+}

--- a/cmd/lsimap/winres/winres.json
+++ b/cmd/lsimap/winres/winres.json
@@ -1,0 +1,53 @@
+{
+  "RT_MANIFEST": {
+    "#1": {
+      "0409": {
+        "identity": {
+          "name": "",
+          "version": ""
+        },
+        "description": "Small CLI tool to list advertised capabilities for specified IMAP server",
+        "minimum-os": "win7",
+        "execution-level": "as invoker",
+        "ui-access": false,
+        "auto-elevate": false,
+        "dpi-awareness": "system",
+        "disable-theming": false,
+        "disable-window-filtering": false,
+        "high-resolution-scrolling-aware": false,
+        "ultra-high-resolution-scrolling-aware": false,
+        "long-path-aware": false,
+        "printer-driver-isolation": false,
+        "gdi-scaling": false,
+        "segment-heap": false,
+        "use-common-controls-v6": false
+      }
+    }
+  },
+  "RT_VERSION": {
+    "#1": {
+      "0000": {
+        "fixed": {
+          "file_version": "0.0.0.0",
+          "product_version": "0.0.0.0"
+        },
+        "info": {
+          "0409": {
+            "Comments": "Part of the atc0005/check-mail project",
+            "CompanyName": "github.com/atc0005",
+            "FileDescription": "Small CLI tool to list advertised capabilities for specified IMAP server",
+            "FileVersion": "",
+            "InternalName": "lsimap",
+            "LegalCopyright": "© Adam Chalkley. Licensed under MIT.",
+            "LegalTrademarks": "",
+            "OriginalFilename": "main.go",
+            "PrivateBuild": "",
+            "ProductName": "check-mail",
+            "ProductVersion": "",
+            "SpecialBuild": ""
+          }
+        }
+      }
+    }
+  }
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -73,6 +73,15 @@ type AppType struct {
 	//
 	// Basic Authentication is used to login.
 	ReporterIMAPMailboxBasicAuth bool
+
+	// InspectorIMAPCaps represents an application used for one-off or
+	// isolated checks of an IMAP server's advertised capabilities.
+	//
+	// Unlike a monitoring plugin which is focused on specific attributes
+	// resulting in a severity-based outcome, an Inspector application is
+	// intended for examining a small set of targets for
+	// informational/troubleshooting purposes.
+	InspectorIMAPCaps bool
 }
 
 // MailAccount represents an email account listed within a configuration file.

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -24,14 +24,20 @@ func (c *Config) handleFlagsConfig(appType AppType) {
 	flag.StringVar(&c.NetworkType, "net-type", defaultNetworkType, networkTypeFlagHelp)
 	flag.StringVar(&c.minTLSVersion, "min-tls", defaultMinTLSVersion, minTLSVersionFlagHelp)
 
-	// currently only applies to list-emails app, don't expose to Nagios plugin
+	// Only applies to Reporter app
 	if appType.ReporterIMAPMailboxBasicAuth {
 		flag.StringVar(&c.ConfigFile, "config-file", defaultINIConfigFileName, iniConfigFileFlagHelp)
 		flag.StringVar(&c.ReportFileOutputDir, "report-file-dir", defaultReportFileOutputDir, reportFileOutputDirFlagHelp)
 		flag.StringVar(&c.LogFileOutputDir, "log-file-dir", defaultLogFileOutputDir, logFileOutputDirFlagHelp)
 	}
 
-	// currently only applies to Nagios plugin
+	// Inspector app
+	if appType.InspectorIMAPCaps {
+		flag.StringVar(&account.Server, "server", defaultServer, serverFlagHelp)
+		flag.IntVar(&account.Port, "port", defaultPort, portFlagHelp)
+	}
+
+	// Basic Auth Plugin
 	if appType.PluginIMAPMailboxBasicAuth {
 		flag.Var(&account.Folders, "folders", foldersFlagHelp)
 		flag.StringVar(&account.Username, "username", defaultUsername, usernameFlagHelp)

--- a/internal/mbxs/connect.go
+++ b/internal/mbxs/connect.go
@@ -66,10 +66,9 @@ func openConnection(addrs []string, port int, dialer Dialer, tlsConfig *tls.Conf
 		}
 
 		// If no connection errors were received, we can consider the
-		// connection attempt a success, clear any previous error and abort
-		// attempts to connect to any remaining IP Addresses for the specified
-		// server name.
-		logger.Info().
+		// connection attempt a success and skip further attempts to connect
+		// to any remaining IP Addresses for the specified server name.
+		logger.Debug().
 			Str("ip_address", addr).
 			Msg("Connected to server")
 
@@ -299,7 +298,7 @@ func Login(c *client.Client, username string, password string, logger zerolog.Lo
 
 		return fmt.Errorf("%s: %w", errMsg, err)
 	}
-	logger.Info().Msg("Logged in")
+	logger.Debug().Msg("Logged in")
 
 	return nil
 


### PR DESCRIPTION
The lsimap binary is intended to provide a simple CLI tool to list advertised IMAP server capabilities.

As part of implementing this tool some minor tweaks were made to the config and mbxs packages to mute some existing log messages by default. Equivalent log output was added to the check_imap_mailbox and list-emails tools to compensate for the change.

README updated with examples for lsimap tool.