### PR TITLE
Adding missing post-config load validation

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -312,6 +312,7 @@ func New(appType AppType) (*Config, error) {
 		return nil, ErrVersionRequested
 	}
 
+	// Initial validation pass using flag values only.
 	if err := config.validate(appType); err != nil {
 		return nil, fmt.Errorf("configuration validation failed: %w", err)
 	}
@@ -336,6 +337,14 @@ func New(appType AppType) (*Config, error) {
 			config.Log.Error().Err(err).Msgf(errMsg)
 
 			return nil, fmt.Errorf("%s: %w", errMsg, err)
+		}
+
+		// Final validation pass using flag AND config file values.
+		if err := config.validate(appType); err != nil {
+			return nil, fmt.Errorf(
+				"configuration validation after loading config file failed: %w",
+				err,
+			)
 		}
 	}
 


### PR DESCRIPTION
While working on a separate change I noticed that config validation is applied as expected after parsing flags, but not after loading a config file.

This PR adds a repeat validation step just after successfully loading a config file.

fixes GH-341