### PR TITLE
Modify fallback logger for plugins, script tools

### DIFF
--- a/cmd/check_imap_mailbox_basic/main.go
+++ b/cmd/check_imap_mailbox_basic/main.go
@@ -13,12 +13,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"time"
-
-	zlog "github.com/rs/zerolog/log"
 
 	"github.com/atc0005/check-mail/internal/config"
 	"github.com/atc0005/go-nagios"
+	"github.com/rs/zerolog"
 )
 
 func main() {
@@ -48,9 +48,13 @@ func main() {
 		return
 
 	case cfgErr != nil:
-		// We're using the standalone Err function from rs/zerolog/log as we
-		// do not have a working configuration.
-		zlog.Err(cfgErr).Msg("Error initializing application")
+		// We make some assumptions when setting up our logger as we do not
+		// have a working configuration based on sysadmin-specified choices.
+		consoleWriter := zerolog.ConsoleWriter{Out: os.Stderr, NoColor: true}
+		logger := zerolog.New(consoleWriter).With().Timestamp().Caller().Logger()
+
+		logger.Err(cfgErr).Msg("Error initializing application")
+
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error initializing application",
 			nagios.StateCRITICALLabel,

--- a/cmd/check_imap_mailbox_oauth2/main.go
+++ b/cmd/check_imap_mailbox_oauth2/main.go
@@ -13,13 +13,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
-	zlog "github.com/rs/zerolog/log"
-
 	"github.com/atc0005/check-mail/internal/config"
 	"github.com/atc0005/go-nagios"
+	"github.com/rs/zerolog"
 )
 
 func main() {
@@ -49,9 +49,13 @@ func main() {
 		return
 
 	case cfgErr != nil:
-		// We're using the standalone Err function from rs/zerolog/log as we
-		// do not have a working configuration.
-		zlog.Err(cfgErr).Msg("Error initializing application")
+		// We make some assumptions when setting up our logger as we do not
+		// have a working configuration based on sysadmin-specified choices.
+		consoleWriter := zerolog.ConsoleWriter{Out: os.Stderr, NoColor: true}
+		logger := zerolog.New(consoleWriter).With().Timestamp().Caller().Logger()
+
+		logger.Err(cfgErr).Msg("Error initializing application")
+
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error initializing application",
 			nagios.StateCRITICALLabel,

--- a/cmd/fetch-token/main.go
+++ b/cmd/fetch-token/main.go
@@ -44,7 +44,7 @@ func main() {
 
 		// We make some assumptions when setting up our logger as we do not
 		// have a working configuration based on sysadmin-specified choices.
-		consoleWriter := zerolog.ConsoleWriter{Out: os.Stderr}
+		consoleWriter := zerolog.ConsoleWriter{Out: os.Stderr, NoColor: true}
 		logger := zerolog.New(consoleWriter).With().Timestamp().Caller().Logger()
 
 		logger.Err(cfgErr).Msg("Error initializing application")

--- a/cmd/read-token/main.go
+++ b/cmd/read-token/main.go
@@ -41,7 +41,7 @@ func main() {
 
 		// We make some assumptions when setting up our logger as we do not
 		// have a working configuration based on sysadmin-specified choices.
-		consoleWriter := zerolog.ConsoleWriter{Out: os.Stderr}
+		consoleWriter := zerolog.ConsoleWriter{Out: os.Stderr, NoColor: true}
 		logger := zerolog.New(consoleWriter).With().Timestamp().Caller().Logger()
 
 		logger.Err(cfgErr).Msg("Error initializing application")


### PR DESCRIPTION
- logger for plugins now uses the consolewriter formatter with an explicit "nocolor" setting instead of a default package formatter (which does not match what the plugin now uses)
- logger for CLI "script" tools updated to use an explicit "nocolor" setting

The `list-emails` CLI app logging configuration is unchanged (for now).