### PR TITLE
Remove indirect dependencies from tools/go.mod

### DIFF
--- a/dependabot/tools/go.mod
+++ b/dependabot/tools/go.mod
@@ -4,13 +4,3 @@ go 1.19
 
 // go-winres - used by go generate build step
 require github.com/tc-hib/go-winres v0.3.1
-
-require (
-	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
-	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 // indirect
-	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/tc-hib/winres v0.1.6 // indirect
-	github.com/urfave/cli/v2 v2.23.7 // indirect
-	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
-	golang.org/x/image v0.0.0-20210220032944-ac19c3e999fb // indirect
-)


### PR DESCRIPTION
Drop tracking of indirect dependencies to reduce unrelated PR traffic.