### PR TITLE
Use UNKNOWN state for invalid command-line args

### DIFF
--- a/cmd/check_imap_mailbox_basic/main.go
+++ b/cmd/check_imap_mailbox_basic/main.go
@@ -53,10 +53,10 @@ func main() {
 
 		plugin.ServiceOutput = fmt.Sprintf(
 			"%s: Error initializing application",
-			nagios.StateCRITICALLabel,
+			nagios.StateUNKNOWNLabel,
 		)
 		plugin.AddError(cfgErr)
-		plugin.ExitStatusCode = nagios.StateCRITICALExitCode
+		plugin.ExitStatusCode = nagios.StateUNKNOWNExitCode
 
 		return
 	}

--- a/cmd/check_imap_mailbox_oauth2/main.go
+++ b/cmd/check_imap_mailbox_oauth2/main.go
@@ -54,10 +54,10 @@ func main() {
 
 		plugin.ServiceOutput = fmt.Sprintf(
 			"%s: Error initializing application",
-			nagios.StateCRITICALLabel,
+			nagios.StateUNKNOWNLabel,
 		)
 		plugin.AddError(cfgErr)
-		plugin.ExitStatusCode = nagios.StateCRITICALExitCode
+		plugin.ExitStatusCode = nagios.StateUNKNOWNExitCode
 
 		return
 	}


### PR DESCRIPTION
Update handling of invalid flags/values to use an UNKNOWN exit state to comply with Nagios Plugin Guideline
recommendations.

refs atc0005/check-mail#386
refs atc0005/todo#55
refs https://nagios-plugins.org/doc/guidelines.html