### PR TITLE
Add todo/release label to "Go Runtime" PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -102,6 +102,7 @@ updates:
     labels:
       - "dependencies"
       - "CI"
+      - "todo/release"
     allow:
       - dependency-type: "all"
     commit-message:
@@ -125,6 +126,7 @@ updates:
     labels:
       - "dependencies"
       - "CI"
+      - "todo/release"
     allow:
       - dependency-type: "all"
     commit-message:


### PR DESCRIPTION
This label is intended to provide a "hook" for Dependabot generated
"Go Runtime" PRs for later automation purposes.
