### PR TITLE
Remove inactive maligned linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,7 +27,6 @@ linters:
     - goimports
     - gosec
     - govet
-    - maligned
     - misspell
     - prealloc
     - revive


### PR DESCRIPTION
This linter has been deprecated for a while with the suggestion to use
govet 'fieldalignment'.

As of a recent release the linter no longer produced a report.

As of the v1.59.0 release attempting to use this linter produces an
error.

Remove all references to this linter from the .golangci.yml config
file bundled in this repo.
