### PR TITLE
Fix errcheck linting errors

### DIFF
--- a/cmd/xoauth2/main.go
+++ b/cmd/xoauth2/main.go
@@ -26,8 +26,8 @@ type credentials struct {
 // Usage is a custom override for the default Help text provided by the flag
 // package. Here we prepend some additional metadata to the existing output.
 func Usage() {
-	fmt.Fprintln(flag.CommandLine.Output(), "\n"+config.Version()+"\n")
-	fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s:\n", os.Args[0])
+	_, _ = fmt.Fprintln(flag.CommandLine.Output(), "\n"+config.Version()+"\n")
+	_, _ = fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s:\n", os.Args[0])
 	flag.PrintDefaults()
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -341,7 +341,7 @@ func Usage(flagSet *flag.FlagSet, w io.Writer) func() {
 	// Uninitialized flagset, provide stub usage information.
 	case flagSet == nil:
 		return func() {
-			fmt.Fprintln(w, "Failed to initialize configuration; nil FlagSet")
+			_, _ = fmt.Fprintln(w, "Failed to initialize configuration; nil FlagSet")
 		}
 
 	// Non-nil flagSet, proceed
@@ -352,8 +352,8 @@ func Usage(flagSet *flag.FlagSet, w io.Writer) func() {
 		flagSet.SetOutput(w)
 
 		return func() {
-			fmt.Fprintln(flag.CommandLine.Output(), "\n"+Version()+"\n")
-			fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s:\n", os.Args[0])
+			_, _ = fmt.Fprintln(flag.CommandLine.Output(), "\n"+Version()+"\n")
+			_, _ = fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s:\n", os.Args[0])
 			flagSet.PrintDefaults()
 		}
 	}
@@ -373,7 +373,7 @@ func (c *Config) Help() string {
 	// Handle nil configuration initialization.
 	case c == nil || c.flagSet == nil:
 		// Fallback message noting the issue.
-		fmt.Fprintln(&helpTxt, ErrConfigNotInitialized)
+		_, _ = fmt.Fprintln(&helpTxt, ErrConfigNotInitialized)
 
 	default:
 		// Emit expected help output to builder.

--- a/internal/textutils/inspect.go
+++ b/internal/textutils/inspect.go
@@ -32,7 +32,7 @@ func inspectString(s string, w io.Writer) error {
 		}
 
 		// fmt.Printf(
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			tw,
 			"char %d: %c\t"+
 				"Decimal: %d\t"+
@@ -61,7 +61,7 @@ func inspectString(s string, w io.Writer) error {
 
 	}
 
-	fmt.Fprintln(w)
+	_, _ = fmt.Fprintln(w)
 	if err := tw.Flush(); err != nil {
 		return fmt.Errorf(
 			"error occurred flushing tabwriter: %w",
@@ -81,7 +81,7 @@ func InspectStrings(ss []string, w io.Writer) error {
 
 	for i, s := range ss {
 
-		fmt.Fprintf(w, "\nstring %d: %q\n", i, s)
+		_, _ = fmt.Fprintf(w, "\nstring %d: %q\n", i, s)
 
 		err := inspectString(s, w)
 		if err != nil {
@@ -100,7 +100,7 @@ func InspectStrings(ss []string, w io.Writer) error {
 // interface.
 func InspectString(s string, w io.Writer) error {
 
-	fmt.Fprintf(w, "\nstring: %q\n", s)
+	_, _ = fmt.Fprintf(w, "\nstring: %q\n", s)
 
 	err := inspectString(s, w)
 	if err != nil {


### PR DESCRIPTION
Resolve `return value of fmt.Fprintf is not checked`` errors by
explicitly discarding return values (potential error, bytes written)
since we do not need them and the potential for failure (in this
particular use case) is *highly* unlikely.
