### PR TITLE
Fix govet linting errors raised by updated linter

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -439,7 +439,7 @@ func New(appType AppType) (*Config, error) {
 			// someone needs to debug later what happened (and the person
 			// running the application didn't catch the error output).
 			errMsg := "failed to load configuration file"
-			config.Log.Error().Err(err).Msgf(errMsg)
+			config.Log.Error().Err(err).Msg(errMsg)
 
 			return nil, fmt.Errorf("%s: %w", errMsg, err)
 		}

--- a/internal/mbxs/auth.go
+++ b/internal/mbxs/auth.go
@@ -31,14 +31,9 @@ var (
 func Login(c *client.Client, username string, password string, logger zerolog.Logger) error {
 
 	if c == nil {
-		errMsg := fmt.Sprintf(
-			"invalid (nil) client received while attempting login for account %s",
-			username,
-		)
+		logger.Error().Str("account", username).Msg("invalid (nil) client received while attempting login")
 
-		logger.Error().Msg(errMsg)
-
-		return fmt.Errorf(errMsg)
+		return fmt.Errorf("invalid (nil) client received while attempting login for account: %v", username)
 	}
 
 	// Due to logic applied during connection establishment this is highly
@@ -115,14 +110,9 @@ func OAuth2ClientCredsAuth(
 ) error {
 
 	if imapClient == nil {
-		errMsg := fmt.Sprintf(
-			"invalid (nil) client received while attempting login for client ID %s",
-			clientID,
-		)
+		logger.Error().Str("client_id", clientID).Msg("invalid (nil) client received while attempting login")
 
-		logger.Error().Msg(errMsg)
-
-		return fmt.Errorf(errMsg)
+		return fmt.Errorf("invalid (nil) client received while attempting login for client ID: %v", clientID)
 	}
 
 	// Due to logic applied during connection establishment this is highly

--- a/internal/mbxs/connect.go
+++ b/internal/mbxs/connect.go
@@ -24,11 +24,9 @@ import (
 func openConnection(addrs []string, port int, dialer Dialer, tlsConfig *tls.Config, logger zerolog.Logger) (*client.Client, error) {
 
 	if len(addrs) < 1 {
-		errMsg := "empty list of IP Addresses received"
+		logger.Error().Msg("empty list of IP Addresses received")
 
-		logger.Error().Msg(errMsg)
-
-		return nil, fmt.Errorf(errMsg)
+		return nil, fmt.Errorf("empty list of IP Addresses received")
 	}
 
 	var c *client.Client
@@ -119,15 +117,9 @@ func Connect(server string, port int, netType string, minTLSVer uint16, logger z
 
 	switch {
 	case len(lookupResults) < 1:
-		errMsg := fmt.Sprintf(
-			"failed to resolve hostname %s to IP Addresses",
-			server,
-		)
+		logger.Error().Str("server", server).Msg("failed to resolve hostname to IP Addresses")
 
-		logger.Error().
-			Msg(errMsg)
-
-		return nil, fmt.Errorf(errMsg)
+		return nil, fmt.Errorf("failed to resolve hostname to IP Addresses: %v", server)
 
 	default:
 		logger.Debug().
@@ -155,15 +147,19 @@ func Connect(server string, port int, netType string, minTLSVer uint16, logger z
 
 	switch {
 	case len(ips) < 1:
-		errMsg := fmt.Sprintf(
+		numLookupResults := len(lookupResults)
+		lookupResultsList := strings.Join(lookupResults, ", ")
+
+		logger.Error().
+			Int("num_lookup_results", numLookupResults).
+			Str("lookup_results", lookupResultsList).
+			Msg("failed to to convert DNS lookup results to net.IP values after receiving DNS lookup results")
+
+		return nil, fmt.Errorf(
 			"failed to to convert DNS lookup results to net.IP values after receiving %d DNS lookup results ([%s])",
-			len(lookupResults),
-			strings.Join(lookupResults, ", "),
+			numLookupResults,
+			lookupResultsList,
 		)
-
-		logger.Error().Msg(errMsg)
-
-		return nil, fmt.Errorf(errMsg)
 
 	default:
 		logger.Debug().Msg("successfully converted DNS lookup results to net.IP values")
@@ -208,15 +204,19 @@ func Connect(server string, port int, netType string, minTLSVer uint16, logger z
 	// requirement.
 	switch {
 	case len(addrs) < 1:
-		errMsg := fmt.Sprintf(
+		numLookupResults := len(lookupResults)
+		lookupResultsList := strings.Join(lookupResults, ", ")
+
+		logger.Error().
+			Int("num_lookup_results", numLookupResults).
+			Str("lookup_results", lookupResultsList).
+			Msg("failed to gather IP Addresses for connection attempts after receiving and parsing DNS lookup results")
+
+		return nil, fmt.Errorf(
 			"failed to gather IP Addresses for connection attempts after receiving and parsing %d DNS lookup results ([%s])",
-			len(lookupResults),
-			strings.Join(lookupResults, ", "),
+			numLookupResults,
+			lookupResultsList,
 		)
-
-		logger.Error().Msg(errMsg)
-
-		return nil, fmt.Errorf(errMsg)
 
 	default:
 		logger.Debug().


### PR DESCRIPTION
Surfaced by golangci-lint v1.60.1 (built with Go 1.23.0).