### PR TITLE
Revert "Go Runtime: Bump golang from 1.21.13 to 1.22rc2 in /dependabot/docker/go"

### DIFF
--- a/dependabot/docker/go/Dockerfile
+++ b/dependabot/docker/go/Dockerfile
@@ -15,4 +15,4 @@
 # binaries) to reflect that version of Go.
 
 # https://hub.docker.com/_/golang
-FROM golang:1.22rc2
+FROM golang:1.21.13


### PR DESCRIPTION
This reverts commit 103e029f837e6eced5f362fe89b893e7a34c7b5a.

I missed that https://github.com/atc0005/check-mail/pull/762 applied the wrong change (presumably a Dependabot bug).