### PR TITLE
Update enclosing error message prefix

### DIFF
--- a/internal/mbxs/auth.go
+++ b/internal/mbxs/auth.go
@@ -134,7 +134,7 @@ func OAuth2ClientCredsAuth(
 	if err != nil {
 		logger.Debug().Err(err).Msg("Failed to retrieve token")
 		return fmt.Errorf(
-			"failed to retrieve token: %w",
+			"failed to authenticate: %w",
 			err,
 		)
 	}


### PR DESCRIPTION
Reduce duplication by clarifying the intent behind the calling function (by way of updating the wrapping error msg prefix).

refs GH-815