### PR TITLE
Fix `copyloopvar` linting errors

### DIFF
--- a/cmd/check_imap_mailbox_basic/main.go
+++ b/cmd/check_imap_mailbox_basic/main.go
@@ -76,7 +76,10 @@ func main() {
 		//
 		// As a workaround, we create a new variable for each iteration to
 		// work around potential issues with Go versions prior to Go 1.22.
-		account := account
+		//
+		// NOTE: Not needed as of Go 1.22.
+		//
+		// account := account
 
 		logger := cfg.Log.With().
 			Str("username", account.Username).

--- a/cmd/check_imap_mailbox_basic/summary.go
+++ b/cmd/check_imap_mailbox_basic/summary.go
@@ -43,7 +43,10 @@ func setSummary(accounts []config.MailAccount, nes *nagios.Plugin) {
 		//
 		// As a workaround, we create a new variable for each iteration to
 		// work around potential issues with Go versions prior to Go 1.22.
-		account := account
+		//
+		// NOTE: Not needed as of Go 1.22.
+		//
+		// account := account
 
 		accountSummary := fmt.Sprintf(
 			"* Account: %s%s** Folders: %s%s%s",

--- a/cmd/list-emails/main.go
+++ b/cmd/list-emails/main.go
@@ -94,7 +94,10 @@ func main() {
 		//
 		// As a workaround, we create a new variable for each iteration to
 		// work around potential issues with Go versions prior to Go 1.22.
-		account := account
+		//
+		// NOTE: Not needed as of Go 1.22.
+		//
+		// account := account
 
 		fmt.Println("Checking account:", account.Name)
 

--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -36,7 +36,10 @@ func (c *Config) readConfigFile(configFile ...string) ([]byte, error) {
 		//
 		// As a workaround, we create a new variable for each iteration to
 		// work around potential issues with Go versions prior to Go 1.22.
-		file := file
+		//
+		// NOTE: Not needed as of Go 1.22.
+		//
+		// file := file
 
 		c.Log.Debug().Str("config_file", file).Msg("Attempting to open config file")
 


### PR DESCRIPTION
Comment out workarounds for `G601: Implicit memory aliasing`.