### PR TITLE
Fix `copyloopvar` linting errors

### DIFF
--- a/cmd/check_imap_mailbox_oauth2/main.go
+++ b/cmd/check_imap_mailbox_oauth2/main.go
@@ -77,7 +77,10 @@ func main() {
 		//
 		// As a workaround, we create a new variable for each iteration to
 		// work around potential issues with Go versions prior to Go 1.22.
-		account := account
+		//
+		// NOTE: Not needed as of Go 1.22.
+		//
+		// account := account
 
 		logger := cfg.Log.With().
 			Str("client_id", account.OAuth2Settings.ClientID).

--- a/cmd/check_imap_mailbox_oauth2/summary.go
+++ b/cmd/check_imap_mailbox_oauth2/summary.go
@@ -43,7 +43,10 @@ func setSummary(accounts []config.MailAccount, nes *nagios.Plugin) {
 		//
 		// As a workaround, we create a new variable for each iteration to
 		// work around potential issues with Go versions prior to Go 1.22.
-		account := account
+		//
+		// NOTE: Not needed as of Go 1.22.
+		//
+		// account := account
 
 		accountSummary := fmt.Sprintf(
 			"* Account: %s%s** Folders: %s%s%s",


### PR DESCRIPTION
Comment out workarounds for `G601: Implicit memory aliasing`.